### PR TITLE
tmpfile() doesn't work when user does not have correct access privileges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ test/**/*log.dat
 test/**/trajectory.dat
 
 **/*pyc
+.vscode

--- a/src/Utilities/Utils.cpp
+++ b/src/Utilities/Utils.cpp
@@ -156,7 +156,7 @@ input_file *get_input_file_from_string(const std::string &inp) {
 		// system using <unistd.h>
 		char* temp_fname;
 		if (const char* temp_prefix = std::getenv("TMPDIR")) {
-			if (MKSTEMP == 0) {
+			if (MKSTEMP == 1) {
 				const char* temp_suffix = "/oxdna-tmp-XXXXXX";
 				temp_fname = (char*)malloc(strlen(temp_prefix) + strlen(temp_suffix) + 1);
 				strcpy(temp_fname, temp_prefix);

--- a/src/Utilities/Utils.h
+++ b/src/Utilities/Utils.h
@@ -21,6 +21,28 @@
 
 #include "../defs.h"
 
+
+/*
+In the function get_input_file_from_string a temporary file
+is created using tmpfile(). This does not work on some systems
+where the user does not have access to the generic temporary 
+directory e.g. /tmp
+
+When using tmpfile() it is not possible to select the temporary
+directory location. So a workaround is needed to allow a user 
+to set an environment variable called TMPDIR that 
+get_input_file_from_string is able to read. 
+
+We can use MKSTEMP from the unix standard library. The include
+directive for this is stored here.
+*/
+#if defined(unix) || defined(__unix__) || defined(__unix)
+#define MKSTEMP 1
+#include <unistd.h>
+#else 
+#define MKSTEMP 0
+#endif
+
 class BaseParticle;
 
 /**


### PR DESCRIPTION
I have had an issue with creating temporary files - but have created a fix that preserves the original functionality (I think)

I have basically replaced `if(temp == NULL) throw oxDNAException("Failed to create a temporary file, exiting");` with:

```c++
if (temp == NULL) {
	OX_LOG(Logger::LOG_DEBUG, "Failed to open file with tmpfile(), trying mkstemp()");
	// Try to use mkstemp - this is only possible on unix 
	// system using <unistd.h>
	char* temp_fname;
	if (const char* temp_prefix = std::getenv("TMPDIR")) {
		if (MKSTEMP == 1) {
			const char* temp_suffix = "/oxdna-tmp-XXXXXX";
			temp_fname = (char*)malloc(strlen(temp_prefix) + strlen(temp_suffix) + 1);
			strcpy(temp_fname, temp_prefix);
			strcat(temp_fname, temp_suffix);
			if (mkstemp(temp_fname) != -1) {
				temp = fopen(temp_fname, "wb+");
			} else {
				throw oxDNAException(
					"Failed to create a temporary file using tmpdir() and then with mkstemp(), Exiting..."
				);
			}
		} else {
			throw oxDNAException(
				"Failed to create a temporary file using tmpfile(), found TMPDIR but it can only be used on UNIX systems, Exiting..."
			);
		}
	} else {
		throw oxDNAException(
			"Failed to create a temporary file using tmpfile(), try setting TMPDIR to an accessible location, Exiting..."
		);
	}
}
```

This is an improvement because:

1. There are more error messages
2. The old behaviour is the default behaviour
3. The user can set the effective temporary directory by setting `TMPDIR` as an environment variable - which seems to be the standard (I'm not 100% sure if this is true)

Some potential problems:

1. This has only been tested on Linux
2. This has only been tested on one type of machine (the cluster at Imperial College)
3. There has not been anyone who has proofread what I have put

Let me know any thoughts here and I can answer questions if there are any