### PR TITLE
print history file in REMD at every step

### DIFF
--- a/examples/OXPY_REMD/remd.py
+++ b/examples/OXPY_REMD/remd.py
@@ -161,6 +161,10 @@ with oxpy.Context():
                             rates [talk_to] = exchange[talk_to] / exchange_tries[talk_to]
 
             history.append(locations)
+            with open("history.json", "w") as file:
+                file.write(
+                    json.dumps(history)
+                )
             remd_log(0, "rates:", rates)
         else:
             # notify 0 of update


### PR DESCRIPTION
- update to save the switch history at every step in REMD.
- prevents data loss if process is interrupted. 