### PR TITLE
Clean up include paths for pybind11, python_defs.

### DIFF
--- a/oxpy/bindings_includes/BaseBox.h
+++ b/oxpy/bindings_includes/BaseBox.h
@@ -8,7 +8,7 @@
 #ifndef OXPY_BINDINGS_INCLUDES_FORCES_BASEBOX_H_
 #define OXPY_BINDINGS_INCLUDES_FORCES_BASEBOX_H_
 
-#include "../../python_defs.h"
+#include "../python_defs.h"
 
 #include <Boxes/BaseBox.h>
 

--- a/oxpy/bindings_includes/ConfigInfo.h
+++ b/oxpy/bindings_includes/ConfigInfo.h
@@ -9,9 +9,6 @@
 #define OXPY_BINDINGS_INCLUDES_CONFIGINFO_H_
 
 #include <Utilities/ConfigInfo.h>
-
-#include "../pybind11/include/pybind11/detail/common.h"
-#include "../pybind11/include/pybind11/pybind11.h"
 #include "../python_defs.h"
 
 void export_ConfigInfo(py::module &m) {


### PR DESCRIPTION
In BaseBox.h, the include path for python_defs.h actually goes up one directory too high; this is obscured by the way pybind11 is included, but fails if a system pybind11 is used.

In ConfigInfo.h, direct relative paths to pybind11 headers are used, but cmake already includes the pybind11 include path, so standard paths can be used instead.  This simplifies use of system pybind11 headers (by a one-line cmake change) where necessary, for example, to fit Debian packaging policies.

Neither change should have any effect on the normal build process.