### PR TITLE
Merge the stress autocorrelation & DNA/RNA GPU interaction performance improvements

### DIFF
--- a/contrib/rovigatti/src/Interactions/CUDAAOInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAAOInteraction.cu
@@ -105,8 +105,8 @@ void CUDAAOInteraction::get_settings(input_file &inp) {
 	AOInteraction::get_settings(inp);
 }
 
-void CUDAAOInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDAAOInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	AOInteraction::init();
 
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_N, &N, sizeof(int)));

--- a/contrib/rovigatti/src/Interactions/CUDAAOInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAAOInteraction.h
@@ -21,7 +21,7 @@ public:
 	virtual ~CUDAAOInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDACPMixtureInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDACPMixtureInteraction.cu
@@ -116,8 +116,8 @@ void CUDACPMixtureInteraction::get_settings(input_file &inp) {
 	CPMixtureInteraction::get_settings(inp);
 }
 
-void CUDACPMixtureInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDACPMixtureInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	CPMixtureInteraction::init();
 
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_N, &N, sizeof(int)));

--- a/contrib/rovigatti/src/Interactions/CUDACPMixtureInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDACPMixtureInteraction.h
@@ -21,7 +21,7 @@ public:
 	virtual ~CUDACPMixtureInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.cu
@@ -72,7 +72,8 @@ struct __align__(16) CUDA_FS_bond_list {
 	}
 };
 
-__device__ void _patchy_point_two_body_interaction(c_number4 &ppos, c_number4 &qpos, c_number4 &a1, c_number4 &a2, c_number4 &a3, c_number4 &b1, c_number4 &b2, c_number4 &b3, c_number4 &F, c_number4 &torque, CUDA_FS_bond_list *bonds, int q_idx, CUDABox *box) {
+__device__ void _patchy_point_two_body_interaction(c_number4 &ppos, c_number4 &qpos, c_number4 &a1, c_number4 &a2, c_number4 &a3, c_number4 &b1,
+		c_number4 &b2, c_number4 &b3, c_number4 &F, c_number4 &torque, CUDA_FS_bond_list *bonds, int q_idx, CUDAStressTensor &p_st, CUDABox *box) {
 	int ptype = get_particle_btype(ppos);
 	int qtype = get_particle_btype(qpos);
 
@@ -97,10 +98,14 @@ __device__ void _patchy_point_two_body_interaction(c_number4 &ppos, c_number4 &q
 		spherical_energy = 4.f * (SQR(lj_part) - lj_part) + 1.f - MD_spherical_attraction_strength[0];
 	}
 
-	F.x -= r.x * force_module;
-	F.y -= r.y * force_module;
-	F.z -= r.z * force_module;
-	F.w += spherical_energy - MD_spherical_E_cut[0];
+	c_number4 force = {-r.x * force_module,
+			-r.y * force_module,
+			-r.z * force_module,
+			spherical_energy - MD_spherical_E_cut[0]
+	};
+
+	_update_stress_tensor<true>(p_st, r, force);
+	F += force;
 
 	int p_N_patches = MD_N_patches[ptype];
 	int q_N_patches = MD_N_patches[qtype];
@@ -144,11 +149,12 @@ __device__ void _patchy_point_two_body_interaction(c_number4 &ppos, c_number4 &q
 
 						c_number4 p_torque = _cross(p_patch_pos, tmp_force);
 
-						torque -= p_torque;
-						F.x -= tmp_force.x;
-						F.y -= tmp_force.y;
-						F.z -= tmp_force.z;
+						F -= tmp_force;
 						F.w += energy_part;
+						torque -= p_torque;
+
+						force = -tmp_force;
+						_update_stress_tensor<true>(p_st, r, force);
 
 						CUDA_FS_bond &my_bond = bonds[p_patch].new_bond();
 
@@ -161,6 +167,7 @@ __device__ void _patchy_point_two_body_interaction(c_number4 &ppos, c_number4 &q
 							my_bond.q_torque_ref_frame = _vectors_transpose_c_number4_product(b1, b2, b3, _cross(q_patch_pos, tmp_force));
 						}
 						else {
+							my_bond.force = my_bond.p_torque = my_bond.q_torque_ref_frame = make_c_number4(0.f, 0.f, 0.f, 0.f);
 							my_bond.force.w = epsilon;
 						}
 					}
@@ -170,7 +177,8 @@ __device__ void _patchy_point_two_body_interaction(c_number4 &ppos, c_number4 &q
 	}
 }
 
-__device__ void _patchy_KF_two_body_interaction(c_number4 &ppos, c_number4 &qpos, c_number4 &a1, c_number4 &a2, c_number4 &a3, c_number4 &b1, c_number4 &b2, c_number4 &b3, c_number4 &F, c_number4 &torque, CUDA_FS_bond_list *bonds, int q_idx, CUDABox *box) {
+__device__ void _patchy_KF_two_body_interaction(c_number4 &ppos, c_number4 &qpos, c_number4 &a1, c_number4 &a2, c_number4 &a3, c_number4 &b1,
+		c_number4 &b2, c_number4 &b3, c_number4 &F, c_number4 &torque, CUDA_FS_bond_list *bonds, int q_idx, CUDAStressTensor &p_st, CUDABox *box) {
 	int ptype = get_particle_btype(ppos);
 	int qtype = get_particle_btype(qpos);
 
@@ -348,7 +356,9 @@ __device__ void _three_body(CUDA_FS_bond_list *bonds, c_number4 &F, c_number4 &T
 	}
 }
 
-__global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces, c_number4 *torques, c_number4 *three_body_torques, int *matrix_neighs, int *number_neighs, CUDABox *box) {
+__global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces,
+		c_number4 *torques, c_number4 *three_body_torques, int *matrix_neighs, int *number_neighs, CUDAStressTensor *st,
+		CUDABox *box) {
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
@@ -360,6 +370,8 @@ __global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *f
 
 	CUDA_FS_bond_list bonds[CUDADetailedPatchySwapInteraction::MAX_PATCHES];
 
+	CUDAStressTensor p_st;
+
 	int num_neighs = NUMBER_NEIGHBOURS(IND, number_neighs);
 	for(int j = 0; j < num_neighs; j++) {
 		int k_index = NEXT_NEIGHBOUR(IND, j, matrix_neighs);
@@ -369,16 +381,17 @@ __global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *f
 			GPU_quat qo = orientations[k_index];
 			get_vectors_from_quat(qo, b1, b2, b3);
 			if(MD_is_KF[0]) {
-				_patchy_KF_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
+				_patchy_KF_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, p_st, box);
 			}
 			else {
-				_patchy_point_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
+				_patchy_point_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, p_st, box);
 			}
 		}
 	}
 
 	_three_body(bonds, F, T, three_body_forces, three_body_torques);
 
+	st[IND] = p_st;
 	forces[IND] = F;
 	torques[IND] = _vectors_transpose_c_number4_product(a1, a2, a3, T);
 }
@@ -503,16 +516,18 @@ void CUDADetailedPatchySwapInteraction::cuda_init(int N) {
 
 void CUDADetailedPatchySwapInteraction::compute_forces(CUDABaseList *lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox *d_box) {
 	int N = CUDABaseInteraction::_N;
-	thrust::device_ptr < c_number4 > t_forces = thrust::device_pointer_cast(d_forces);
-	thrust::device_ptr < c_number4 > t_torques = thrust::device_pointer_cast(d_torques);
-	thrust::device_ptr < c_number4 > t_three_body_forces = thrust::device_pointer_cast(_d_three_body_forces);
-	thrust::device_ptr < c_number4 > t_three_body_torques = thrust::device_pointer_cast(_d_three_body_torques);
+	thrust::device_ptr<c_number4> t_forces = thrust::device_pointer_cast(d_forces);
+	thrust::device_ptr<c_number4> t_torques = thrust::device_pointer_cast(d_torques);
+	thrust::device_ptr<c_number4> t_three_body_forces = thrust::device_pointer_cast(_d_three_body_forces);
+	thrust::device_ptr<c_number4> t_three_body_torques = thrust::device_pointer_cast(_d_three_body_torques);
 	thrust::fill_n(t_three_body_forces, N, make_c_number4(0, 0, 0, 0));
 	thrust::fill_n(t_three_body_torques, N, make_c_number4(0, 0, 0, 0));
 
+	CUDA_SAFE_CALL(cudaMemset(_d_st, 0, N * sizeof(CUDAStressTensor)));
+
 	DPS_forces
 		<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-		(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, lists->d_matrix_neighs, lists->d_number_neighs, d_box);
+		(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, lists->d_matrix_neighs, lists->d_number_neighs, _d_st, d_box);
 	CUT_CHECK_ERROR("DPS_forces error");
 
 	// add the three body contributions to the two-body forces and torques

--- a/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.cu
@@ -348,8 +348,7 @@ __device__ void _three_body(CUDA_FS_bond_list *bonds, c_number4 &F, c_number4 &T
 	}
 }
 
-// forces + second step without lists
-__global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces, c_number4 *torques, c_number4 *three_body_torques, CUDABox *box) {
+__global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces, c_number4 *torques, c_number4 *three_body_torques, int *matrix_neighs, int *number_neighs, CUDABox *box) {
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
@@ -361,54 +360,20 @@ __global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *f
 
 	CUDA_FS_bond_list bonds[CUDADetailedPatchySwapInteraction::MAX_PATCHES];
 
-	for(int j = 0; j < MD_N[0]; j++) {
-		if(j != IND) {
-			c_number4 qpos = poss[j];
+	int num_neighs = NUMBER_NEIGHBOURS(IND, number_neighs);
+	for(int j = 0; j < num_neighs; j++) {
+		int k_index = NEXT_NEIGHBOUR(IND, j, matrix_neighs);
 
-			GPU_quat qo = orientations[j];
+		if(k_index != IND) {
+			c_number4 qpos = poss[k_index];
+			GPU_quat qo = orientations[k_index];
 			get_vectors_from_quat(qo, b1, b2, b3);
-
 			if(MD_is_KF[0]) {
-				_patchy_KF_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, j, box);
+				_patchy_KF_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
 			}
 			else {
-				_patchy_point_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, j, box);
+				_patchy_point_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
 			}
-		}
-	}
-
-	_three_body(bonds, F, T, three_body_forces, three_body_torques);
-
-	forces[IND] = F;
-	torques[IND] = _vectors_transpose_c_number4_product(a1, a2, a3, T);
-}
-
-// forces + second step with verlet lists
-__global__ void DPS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces, c_number4 *torques, c_number4 *three_body_torques, int *matrix_neighs, int *c_number_neighs, CUDABox *box) {
-	if(IND >= MD_N[0]) return;
-
-	c_number4 F = forces[IND];
-	c_number4 T = torques[IND];
-	c_number4 ppos = poss[IND];
-	GPU_quat po = orientations[IND];
-	c_number4 a1, a2, a3, b1, b2, b3;
-	get_vectors_from_quat(po, a1, a2, a3);
-
-	CUDA_FS_bond_list bonds[CUDADetailedPatchySwapInteraction::MAX_PATCHES];
-
-	int num_neighs = c_number_neighs[IND];
-	for(int j = 0; j < num_neighs; j++) {
-		int k_index = matrix_neighs[j * MD_N[0] + IND];
-
-		c_number4 qpos = poss[k_index];
-
-		GPU_quat qo = orientations[k_index];
-		get_vectors_from_quat(qo, b1, b2, b3);
-		if(MD_is_KF[0]) {
-			_patchy_KF_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
-		}
-		else {
-			_patchy_point_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
 		}
 	}
 
@@ -545,25 +510,10 @@ void CUDADetailedPatchySwapInteraction::compute_forces(CUDABaseList *lists, c_nu
 	thrust::fill_n(t_three_body_forces, N, make_c_number4(0, 0, 0, 0));
 	thrust::fill_n(t_three_body_torques, N, make_c_number4(0, 0, 0, 0));
 
-	CUDASimpleVerletList *_v_lists = dynamic_cast<CUDASimpleVerletList *>(lists);
-	if(_v_lists != NULL) {
-		if(_v_lists->use_edge()) throw oxDNAException("CUDADetailedPatchySwapInteraction: use_edge is unsupported");
-		else {
-			DPS_forces
-				<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-				(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, _v_lists->d_matrix_neighs, _v_lists->d_number_neighs, d_box);
-			CUT_CHECK_ERROR("DPS_forces simple_lists error");
-		}
-	}
-	else {
-		CUDANoList *_no_lists = dynamic_cast<CUDANoList *>(lists);
-		if(_no_lists != NULL) {
-			DPS_forces
-				<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-				(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, d_box);
-			CUT_CHECK_ERROR("DPS_forces no_lists error");
-		}
-	}
+	DPS_forces
+		<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
+		(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, lists->d_matrix_neighs, lists->d_number_neighs, d_box);
+	CUT_CHECK_ERROR("DPS_forces error");
 
 	// add the three body contributions to the two-body forces and torques
 	thrust::transform(t_forces, t_forces + N, t_three_body_forces, t_forces, thrust::plus<c_number4>());

--- a/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.cu
@@ -455,8 +455,8 @@ void CUDADetailedPatchySwapInteraction::get_settings(input_file &inp) {
 	getInputInt(&inp, "CUDA_sort_every", &sort_every, 0);
 }
 
-void CUDADetailedPatchySwapInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDADetailedPatchySwapInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	DetailedPatchySwapInteraction::init();
 
 	CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc(&_d_three_body_forces, N * sizeof(c_number4)));

--- a/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDADetailedPatchySwapInteraction.h
@@ -37,7 +37,7 @@ public:
 	virtual ~CUDADetailedPatchySwapInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDADetailedPolymerSwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDADetailedPolymerSwapInteraction.cu
@@ -343,8 +343,8 @@ void CUDADetailedPolymerSwapInteraction::get_settings(input_file &inp) {
 	DetailedPolymerSwapInteraction::get_settings(inp);
 }
 
-void CUDADetailedPolymerSwapInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDADetailedPolymerSwapInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	DetailedPolymerSwapInteraction::init();
 
 	std::vector<BaseParticle *> particles(_N);

--- a/contrib/rovigatti/src/Interactions/CUDADetailedPolymerSwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDADetailedPolymerSwapInteraction.cu
@@ -259,58 +259,31 @@ __device__ bool _sticky_interaction(int p_btype, int q_btype) {
 	return p_btype != DetailedPolymerSwapInteraction::MONOMER && q_btype != DetailedPolymerSwapInteraction::MONOMER;
 }
 
-// forces + second step without lists
-__global__ void ps_forces(c_number4 *poss, c_number4 *forces, c_number4 *three_body_forces, CUDABox *box) {
+// forces + second step with verlet lists
+__global__ void ps_forces(c_number4 *poss, c_number4 *forces, c_number4 *three_body_forces, int *matrix_neighs, int *number_neighs, CUDABox *box) {
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
 	c_number4 ppos = poss[IND];
+
 	int p_btype = get_particle_btype(ppos);
 
 	CUDA_FS_bond_list bonds;
 
-	for(int j = 0; j < MD_N[0]; j++) {
-		if(j != IND) {
-			c_number4 qpos = poss[j];
+	int num_neighs = NUMBER_NEIGHBOURS(IND, number_neighs);
+	for(int j = 0; j < num_neighs; j++) {
+		int q_index = NEXT_NEIGHBOUR(IND, j, matrix_neighs);
+
+		if(q_index != IND) {
+			c_number4 qpos = poss[q_index];
 			int q_btype = get_particle_btype(qpos);
 
 			_WCA(ppos, qpos, F, box);
-			
+
 			if(_sticky_interaction(p_btype, q_btype)) {
-				int eps_idx = p_btype * MD_interaction_matrix_size[0] + q_btype;
-				_sticky(ppos, qpos, eps_idx, j, F, bonds, box);
+				int eps_idx = p_btype + MD_interaction_matrix_size[0] * q_btype;
+				_sticky(ppos, qpos, eps_idx, q_index, F, bonds, box);
 			}
-		}
-	}
-
-	_sticky_three_body(bonds, F, three_body_forces);
-
-	forces[IND] = F;
-}
-
-// forces + second step with verlet lists
-__global__ void ps_forces(c_number4 *poss, c_number4 *forces, c_number4 *three_body_forces, int *matrix_neighs, int *c_number_neighs, CUDABox *box) {
-	if(IND >= MD_N[0]) return;
-
-	c_number4 F = forces[IND];
-	c_number4 ppos = poss[IND];
-
-	int num_neighs = c_number_neighs[IND];
-	int p_btype = get_particle_btype(ppos);
-
-	CUDA_FS_bond_list bonds;
-
-	for(int j = 0; j < num_neighs; j++) {
-		int q_index = matrix_neighs[j * MD_N[0] + IND];
-
-		c_number4 qpos = poss[q_index];
-		int q_btype = get_particle_btype(qpos);
-
-		_WCA(ppos, qpos, F, box);
-		
-		if(_sticky_interaction(p_btype, q_btype)) {
-			int eps_idx = p_btype + MD_interaction_matrix_size[0] * q_btype;
-			_sticky(ppos, qpos, eps_idx, q_index, F, bonds, box);
 		}
 	}
 
@@ -416,25 +389,10 @@ void CUDADetailedPolymerSwapInteraction::compute_forces(CUDABaseList *lists, c_n
 		(d_poss, d_forces, _d_three_body_forces, _d_bonded_neighs, d_box);
 	CUT_CHECK_ERROR("ps_FENE_flexibility_forces DetailedPolymerSwap error");
 
-	CUDASimpleVerletList *_v_lists = dynamic_cast<CUDASimpleVerletList *>(lists);
-	if(_v_lists != NULL) {
-		if(_v_lists->use_edge()) {
-			throw oxDNAException("use_edge unsupported by DetailedPolymerSwapInteraction");
-		}
-
-		ps_forces
-			<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-			(d_poss, d_forces, _d_three_body_forces, _v_lists->d_matrix_neighs, _v_lists->d_number_neighs, d_box);
-		CUT_CHECK_ERROR("forces_second_step DetailedPolymerSwap simple_lists error");
-	}
-
-	CUDANoList *_no_lists = dynamic_cast<CUDANoList *>(lists);
-	if(_no_lists != NULL) {
-		ps_forces
-			<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-			(d_poss, d_forces, _d_three_body_forces, d_box);
-		CUT_CHECK_ERROR("forces_second_step DetailedPolymerSwap no_lists error");
-	}
+	ps_forces
+		<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
+		(d_poss, d_forces, _d_three_body_forces, lists->d_matrix_neighs, lists->d_number_neighs, d_box);
+	CUT_CHECK_ERROR("forces_second_step DetailedPolymerSwap error");
 
 	// add the three body contributions to the two-body forces
 	thrust::transform(t_forces, t_forces + _N, t_three_body_forces, t_forces, thrust::plus<c_number4>());

--- a/contrib/rovigatti/src/Interactions/CUDADetailedPolymerSwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDADetailedPolymerSwapInteraction.h
@@ -26,7 +26,7 @@ public:
 	virtual ~CUDADetailedPolymerSwapInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDAFSInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAFSInteraction.cu
@@ -365,8 +365,8 @@ void CUDAFSInteraction::get_settings(input_file &inp) {
 	}
 }
 
-void CUDAFSInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDAFSInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	FSInteraction::init();
 
 	std::ifstream topology(_topology_filename, std::ios::in);

--- a/contrib/rovigatti/src/Interactions/CUDAFSInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAFSInteraction.h
@@ -31,7 +31,7 @@ public:
 	virtual ~CUDAFSInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDALevyInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDALevyInteraction.cu
@@ -290,8 +290,8 @@ void CUDALevyInteraction::get_settings(input_file &inp) {
 	}
 }
 
-void CUDALevyInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDALevyInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	LevyInteraction::init();
 
 	_setup_centres();

--- a/contrib/rovigatti/src/Interactions/CUDALevyInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDALevyInteraction.h
@@ -38,7 +38,7 @@ typedef struct
 		}
 		void get_settings(input_file &inp);
 
-		void cuda_init(c_number box_side, int N);
+		void cuda_init(int N);
 
 		void compute_forces(CUDABaseList *lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox *d_box);
 	};

--- a/contrib/rovigatti/src/Interactions/CUDAMGInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAMGInteraction.cu
@@ -139,8 +139,8 @@ void CUDAMGInteraction::get_settings(input_file &inp) {
 	MGInteraction::get_settings(inp);
 }
 
-void CUDAMGInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDAMGInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	MGInteraction::init();
 
 	std::vector<BaseParticle *> particles(_N);

--- a/contrib/rovigatti/src/Interactions/CUDAMGInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAMGInteraction.h
@@ -23,7 +23,7 @@ public:
 	virtual ~CUDAMGInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDAPatchySwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAPatchySwapInteraction.cu
@@ -199,8 +199,7 @@ __device__ void _three_body(CUDA_FS_bond_list *bonds, c_number4 &F, c_number4 &T
 	}
 }
 
-// forces + second step without lists
-__global__ void PS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces, c_number4 *torques, c_number4 *three_body_torques, CUDABox *box) {
+__global__ void PS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces, c_number4 *torques, c_number4 *three_body_torques, int *matrix_neighs, int *number_neighs, CUDABox *box) {
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
@@ -212,44 +211,17 @@ __global__ void PS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *fo
 
 	CUDA_FS_bond_list bonds[CUDAPatchySwapInteraction::MAX_PATCHES];
 
-	for(int j = 0; j < MD_N[0]; j++) {
-		if(j != IND) {
-			c_number4 qpos = poss[j];
-
-			GPU_quat qo = orientations[j];
-			get_vectors_from_quat(qo, b1, b2, b3);
-			_patchy_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, j, box);
-		}
-	}
-
-	_three_body(bonds, F, T, three_body_forces, three_body_torques);
-
-	forces[IND] = F;
-	torques[IND] = _vectors_transpose_c_number4_product(a1, a2, a3, T);
-}
-
-// forces + second step with verlet lists
-__global__ void PS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *three_body_forces, c_number4 *torques, c_number4 *three_body_torques, int *matrix_neighs, int *c_number_neighs, CUDABox *box) {
-	if(IND >= MD_N[0]) return;
-
-	c_number4 F = forces[IND];
-	c_number4 T = torques[IND];
-	c_number4 ppos = poss[IND];
-	GPU_quat po = orientations[IND];
-	c_number4 a1, a2, a3, b1, b2, b3;
-	get_vectors_from_quat(po, a1, a2, a3);
-
-	CUDA_FS_bond_list bonds[CUDAPatchySwapInteraction::MAX_PATCHES];
-
-	int num_neighs = c_number_neighs[IND];
+	int num_neighs = NUMBER_NEIGHBOURS(IND, number_neighs);
 	for(int j = 0; j < num_neighs; j++) {
-		int k_index = matrix_neighs[j * MD_N[0] + IND];
+		int k_index = NEXT_NEIGHBOUR(IND, j, matrix_neighs);
 
-		c_number4 qpos = poss[k_index];
+		if(k_index != IND) {
+			c_number4 qpos = poss[k_index];
 
-		GPU_quat qo = orientations[k_index];
-		get_vectors_from_quat(qo, b1, b2, b3);
-		_patchy_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
+			GPU_quat qo = orientations[k_index];
+			get_vectors_from_quat(qo, b1, b2, b3);
+			_patchy_two_body_interaction(ppos, qpos, a1, a2, a3, b1, b2, b3, F, T, bonds, k_index, box);
+		}
 	}
 
 	_three_body(bonds, F, T, three_body_forces, three_body_torques);
@@ -347,25 +319,10 @@ void CUDAPatchySwapInteraction::compute_forces(CUDABaseList *lists, c_number4 *d
 	thrust::fill_n(t_three_body_forces, N, make_c_number4(0, 0, 0, 0));
 	thrust::fill_n(t_three_body_torques, N, make_c_number4(0, 0, 0, 0));
 
-	CUDASimpleVerletList *_v_lists = dynamic_cast<CUDASimpleVerletList *>(lists);
-	if(_v_lists != NULL) {
-		if(_v_lists->use_edge()) throw oxDNAException("CUDAPatchySwapInteraction: use_edge is unsupported");
-		else {
-			PS_forces
-				<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-				(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, _v_lists->d_matrix_neighs, _v_lists->d_number_neighs, d_box);
-			CUT_CHECK_ERROR("PS_forces simple_lists error");
-		}
-	}
-	else {
-		CUDANoList *_no_lists = dynamic_cast<CUDANoList *>(lists);
-		if(_no_lists != NULL) {
-			PS_forces
-				<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-				(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, d_box);
-			CUT_CHECK_ERROR("PS_forces no_lists error");
-		}
-	}
+	PS_forces
+		<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
+		(d_poss, d_orientations, d_forces, _d_three_body_forces,  d_torques, _d_three_body_torques, lists->d_matrix_neighs, lists->d_number_neighs, d_box);
+	CUT_CHECK_ERROR("PS_forces simple_lists error");
 
 	// add the three body contributions to the two-body forces and torques
 	thrust::transform(t_forces, t_forces + N, t_three_body_forces, t_forces, thrust::plus<c_number4>());

--- a/contrib/rovigatti/src/Interactions/CUDAPatchySwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAPatchySwapInteraction.cu
@@ -285,8 +285,8 @@ void CUDAPatchySwapInteraction::get_settings(input_file &inp) {
 	getInputInt(&inp, "CUDA_sort_every", &sort_every, 0);
 }
 
-void CUDAPatchySwapInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDAPatchySwapInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	PatchySwapInteraction::init();
 
 	if(_N_species > MAX_SPECIES) {

--- a/contrib/rovigatti/src/Interactions/CUDAPatchySwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAPatchySwapInteraction.h
@@ -32,7 +32,7 @@ public:
 	virtual ~CUDAPatchySwapInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDAPolymerInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAPolymerInteraction.h
@@ -20,9 +20,9 @@ public:
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}
-	void get_settings(input_file &inp);
+	void get_settings(input_file &inp) override;
 
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N) override;
 
 	void compute_forces(CUDABaseList *lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox *d_box);
 };

--- a/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.cu
@@ -74,20 +74,6 @@ struct __align__(16) CUDA_FS_bond_list {
 	}
 };
 
-// in the case of pair-wise forces, which are counted twice, one should set half=true
-// while three-body forces are counted only once, so half=false should be used.
-template<bool half>
-__device__ void _update_stress_tensor(CUDAStressTensor &st, c_number4 &r, c_number4 &force) {
-	c_number factor = (half) ? 0.5f : 1.0f;
-
-	st.e[0] -= r.x * force.x * factor;
-	st.e[1] -= r.y * force.y * factor;
-	st.e[2] -= r.z * force.z * factor;
-	st.e[3] -= r.x * force.y * factor;
-	st.e[4] -= r.x * force.z * factor;
-	st.e[5] -= r.y * force.z * factor;
-}
-
 __device__ void _WCA(c_number4 &ppos, c_number4 &qpos, int int_type, c_number4 &F, CUDAStressTensor &p_st, CUDABox *box) {
 	c_number4 r = box->minimum_image(ppos, qpos);
 	c_number sqr_r = CUDA_DOT(r, r);

--- a/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.h
@@ -11,14 +11,64 @@
 #include "CUDA/Interactions/CUDABaseInteraction.h"
 #include "PolymerSwapInteraction.h"
 
-/**
- * @brief CUDA implementation of the {@link PolymerSwapInteraction MicroGel interaction}.
- */
+__device__ __host__ __align__(16) struct CUDAStressTensor {
+	c_number e[6];
 
+	__device__ __host__ CUDAStressTensor() : e{0} {
+
+	}
+
+	__device__ __host__ CUDAStressTensor(c_number e0, c_number e1, c_number e2, c_number e3, c_number e4, c_number e5) :
+		e{e0, e1, e2, e3, e4, e5} {
+
+	}
+
+	__device__ __host__ inline CUDAStressTensor operator+(const CUDAStressTensor &other) const {
+		return CUDAStressTensor(
+				e[0] + other.e[0],
+				e[1] + other.e[1],
+				e[2] + other.e[2],
+				e[3] + other.e[3],
+				e[4] + other.e[4],
+				e[5] + other.e[5]);
+	}
+
+	__device__ __host__ inline void operator+=(const CUDAStressTensor &other) {
+		e[0] += other.e[0];
+		e[1] += other.e[1];
+		e[2] += other.e[2];
+		e[3] += other.e[3];
+		e[4] += other.e[4];
+		e[5] += other.e[5];
+	}
+
+	__host__ inline void operator*=(const c_number other) {
+		e[0] *= other;
+		e[1] *= other;
+		e[2] *= other;
+		e[3] *= other;
+		e[4] *= other;
+		e[5] *= other;
+	}
+
+	__host__ inline void operator/=(const c_number other) {
+		e[0] /= other;
+		e[1] /= other;
+		e[2] /= other;
+		e[3] /= other;
+		e[4] /= other;
+		e[5] /= other;
+	}
+};
+
+/**
+ * @brief CUDA implementation of the {@link PolymerSwapInteraction interaction}.
+ */
 class CUDAPolymerSwapInteraction: public CUDABaseInteraction, public PolymerSwapInteraction {
 private:
-	c_number4 *_d_three_body_forces;
-	int *_d_bonded_neighs;
+	c_number4 *_d_three_body_forces = nullptr;
+	int *_d_bonded_neighs = nullptr;
+	CUDAStressTensor *_d_st = nullptr, *_h_st = nullptr;
 
 public:
 	CUDAPolymerSwapInteraction();

--- a/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.h
@@ -19,12 +19,13 @@ class CUDAPolymerSwapInteraction: public CUDABaseInteraction, public PolymerSwap
 private:
 	c_number4 *_d_three_body_forces;
 	int *_d_bonded_neighs;
+
 public:
 	CUDAPolymerSwapInteraction();
 	virtual ~CUDAPolymerSwapInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAPolymerSwapInteraction.h
@@ -11,56 +11,6 @@
 #include "CUDA/Interactions/CUDABaseInteraction.h"
 #include "PolymerSwapInteraction.h"
 
-__device__ __host__ __align__(16) struct CUDAStressTensor {
-	c_number e[6];
-
-	__device__ __host__ CUDAStressTensor() : e{0} {
-
-	}
-
-	__device__ __host__ CUDAStressTensor(c_number e0, c_number e1, c_number e2, c_number e3, c_number e4, c_number e5) :
-		e{e0, e1, e2, e3, e4, e5} {
-
-	}
-
-	__device__ __host__ inline CUDAStressTensor operator+(const CUDAStressTensor &other) const {
-		return CUDAStressTensor(
-				e[0] + other.e[0],
-				e[1] + other.e[1],
-				e[2] + other.e[2],
-				e[3] + other.e[3],
-				e[4] + other.e[4],
-				e[5] + other.e[5]);
-	}
-
-	__device__ __host__ inline void operator+=(const CUDAStressTensor &other) {
-		e[0] += other.e[0];
-		e[1] += other.e[1];
-		e[2] += other.e[2];
-		e[3] += other.e[3];
-		e[4] += other.e[4];
-		e[5] += other.e[5];
-	}
-
-	__host__ inline void operator*=(const c_number other) {
-		e[0] *= other;
-		e[1] *= other;
-		e[2] *= other;
-		e[3] *= other;
-		e[4] *= other;
-		e[5] *= other;
-	}
-
-	__host__ inline void operator/=(const c_number other) {
-		e[0] /= other;
-		e[1] /= other;
-		e[2] /= other;
-		e[3] /= other;
-		e[4] /= other;
-		e[5] /= other;
-	}
-};
-
 /**
  * @brief CUDA implementation of the {@link PolymerSwapInteraction interaction}.
  */
@@ -68,7 +18,6 @@ class CUDAPolymerSwapInteraction: public CUDABaseInteraction, public PolymerSwap
 private:
 	c_number4 *_d_three_body_forces = nullptr;
 	int *_d_bonded_neighs = nullptr;
-	CUDAStressTensor *_d_st = nullptr, *_h_st = nullptr;
 
 public:
 	CUDAPolymerSwapInteraction();

--- a/contrib/rovigatti/src/Interactions/CUDAStarrInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAStarrInteraction.cu
@@ -273,8 +273,8 @@ void CUDAStarrInteraction::get_settings(input_file &inp) {
 	}
 }
 
-void CUDAStarrInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDAStarrInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	StarrInteraction::init();
 
 	if(this->_mode != StarrInteraction::STRANDS) _setup_hubs();

--- a/contrib/rovigatti/src/Interactions/CUDAStarrInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAStarrInteraction.h
@@ -41,7 +41,7 @@ typedef struct
 		}
 		void get_settings(input_file &inp);
 
-		void cuda_init(c_number box_side, int N);
+		void cuda_init(int N);
 
 		void compute_forces(CUDABaseList *lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox *d_box);
 	};

--- a/contrib/rovigatti/src/Interactions/CUDATSPInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDATSPInteraction.cu
@@ -275,8 +275,8 @@ void CUDATSPInteraction::get_settings(input_file &inp) {
 	}
 }
 
-void CUDATSPInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDATSPInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	TSPInteraction::init();
 
 	_setup_anchors();

--- a/contrib/rovigatti/src/Interactions/CUDATSPInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDATSPInteraction.h
@@ -40,7 +40,7 @@ public:
 	}
 	void get_settings(input_file &inp);
 
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 
 	void compute_forces(CUDABaseList*lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box);
 };

--- a/contrib/rovigatti/src/Interactions/CUDAmWInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/CUDAmWInteraction.cu
@@ -188,8 +188,8 @@ void CUDAmWInteraction::get_settings(input_file &inp) {
 	mWInteraction::get_settings(inp);
 }
 
-void CUDAmWInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDAmWInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	mWInteraction::init();
 
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_N, &N, sizeof(int)));

--- a/contrib/rovigatti/src/Interactions/CUDAmWInteraction.h
+++ b/contrib/rovigatti/src/Interactions/CUDAmWInteraction.h
@@ -24,7 +24,7 @@ public:
 	virtual ~CUDAmWInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Interactions/DetailedPatchySwapInteraction.cpp
+++ b/contrib/rovigatti/src/Interactions/DetailedPatchySwapInteraction.cpp
@@ -108,6 +108,9 @@ number DetailedPatchySwapInteraction::_spherical_patchy_two_body(BaseParticle *p
 			LR_vector force = _computed_r * (-24. * (lj_part - 2 * SQR(lj_part)) / sqr_r);
 			p->force -= force;
 			q->force += force;
+
+			_update_stress_tensor(p->pos, -force);
+			_update_stress_tensor(p->pos + _computed_r, force);
 		}
 	}
 	else {
@@ -119,6 +122,9 @@ number DetailedPatchySwapInteraction::_spherical_patchy_two_body(BaseParticle *p
 				LR_vector force = _computed_r * (-24. * _spherical_attraction_strength * (lj_part - 2 * SQR(lj_part)) / sqr_r);
 				p->force -= force;
 				q->force += force;
+
+				_update_stress_tensor(p->pos, -force);
+				_update_stress_tensor(p->pos + _computed_r, force);
 			}
 		}
 	}
@@ -179,6 +185,9 @@ number DetailedPatchySwapInteraction::_patchy_two_body_point(BaseParticle *p, Ba
 							q_bond.p_torque = -q_torque;
 							q_bond.q_torque = -p_torque;
 						}
+
+						_update_stress_tensor(p->pos, -tmp_force);
+						_update_stress_tensor(p->pos + _computed_r, tmp_force);
 					}
 
 					_particle_bonds(p).emplace_back(p_bond);
@@ -293,6 +302,9 @@ number DetailedPatchySwapInteraction::_patchy_two_body_KF(BaseParticle *p, BaseP
 								q_bond.force = (dist_surf < _sigma_ss) ? -angular_force : -tot_force;
 								q_bond.p_torque = -q_torque;
 								q_bond.q_torque = -p_torque;
+
+								_update_stress_tensor(p->pos, -tot_force);
+								_update_stress_tensor(p->pos + _computed_r, tot_force);
 							}
 
 							_particle_bonds(p).emplace_back(p_bond);

--- a/contrib/rovigatti/src/Interactions/DetailedPatchySwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/DetailedPatchySwapInteraction.h
@@ -99,6 +99,10 @@ public:
 
 	void begin_energy_computation() override;
 
+	bool has_custom_stress_tensor() const override {
+		return true;
+	}
+
 	virtual number pair_interaction(BaseParticle *p, BaseParticle *q, bool compute_r = true, bool update_forces = false);
 	virtual number pair_interaction_bonded(BaseParticle *p, BaseParticle *q, bool compute_r = true, bool update_forces = false);
 	virtual number pair_interaction_nonbonded(BaseParticle *p, BaseParticle *q, bool compute_r = true, bool update_forces = false);

--- a/contrib/rovigatti/src/Interactions/DetailedPolymerSwapInteraction.cpp
+++ b/contrib/rovigatti/src/Interactions/DetailedPolymerSwapInteraction.cpp
@@ -114,6 +114,12 @@ void DetailedPolymerSwapInteraction::begin_energy_computation() {
 	_bonds.clear();
 }
 
+void DetailedPolymerSwapInteraction::begin_energy_and_force_computation() {
+	BaseInteraction::begin_energy_and_force_computation();
+
+	std::fill(_inter_chain_stress_tensor.begin(), _inter_chain_stress_tensor.end(), 0.);
+}
+
 bool DetailedPolymerSwapInteraction::has_custom_stress_tensor() const {
 	return true;
 }

--- a/contrib/rovigatti/src/Interactions/DetailedPolymerSwapInteraction.cpp
+++ b/contrib/rovigatti/src/Interactions/DetailedPolymerSwapInteraction.cpp
@@ -97,7 +97,7 @@ void DetailedPolymerSwapInteraction::_update_inter_chain_stress_tensor(int chain
 
 number DetailedPolymerSwapInteraction::P_inter_chain() {
 	number V = CONFIG_INFO->box->V();
-	return CONFIG_INFO->temperature() * (_N_chains / V) + (_inter_chain_stress_tensor[0] + _inter_chain_stress_tensor[1] + _inter_chain_stress_tensor[2]) / (3. * V);
+	return CONFIG_INFO->temperature() * (_N_chains / V) + (_inter_chain_stress_tensor[0] + _inter_chain_stress_tensor[1] + _inter_chain_stress_tensor[2]) / V;
 }
 
 void DetailedPolymerSwapInteraction::begin_energy_computation() {

--- a/contrib/rovigatti/src/Interactions/DetailedPolymerSwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/DetailedPolymerSwapInteraction.h
@@ -116,6 +116,7 @@ public:
 	virtual void allocate_particles(std::vector<BaseParticle *> &particles);
 
 	void begin_energy_computation() override;
+	void begin_energy_and_force_computation() override;
 
 	bool has_custom_stress_tensor() const override;
 

--- a/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.cpp
+++ b/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.cpp
@@ -135,6 +135,7 @@ number PolymerSwapInteraction::P_inter_chain() {
 void PolymerSwapInteraction::begin_energy_computation() {
 	BaseInteraction::begin_energy_computation();
 
+	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
 	for(int i = 0; i < _N_chains; i++) {
 		for(auto p: CONFIG_INFO->molecules()[i]->particles) {
 			_inter_chain_stress_tensor[0] += SQR(p->vel.x);
@@ -156,7 +157,6 @@ void PolymerSwapInteraction::begin_energy_and_force_computation() {
 	BaseInteraction::begin_energy_and_force_computation();
 
 	std::fill(_inter_chain_stress_tensor.begin(), _inter_chain_stress_tensor.end(), 0.);
-	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
 }
 
 bool PolymerSwapInteraction::has_custom_stress_tensor() const {

--- a/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.cpp
+++ b/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.cpp
@@ -135,9 +135,6 @@ number PolymerSwapInteraction::P_inter_chain() {
 void PolymerSwapInteraction::begin_energy_computation() {
 	BaseInteraction::begin_energy_computation();
 
-	std::fill(_inter_chain_stress_tensor.begin(), _inter_chain_stress_tensor.end(), 0.);
-	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
-
 	for(int i = 0; i < _N_chains; i++) {
 		for(auto p: CONFIG_INFO->molecules()[i]->particles) {
 			_inter_chain_stress_tensor[0] += SQR(p->vel.x);
@@ -153,6 +150,13 @@ void PolymerSwapInteraction::begin_energy_computation() {
 	}
 
 	_bonds.clear();
+}
+
+void PolymerSwapInteraction::begin_energy_and_force_computation() {
+	BaseInteraction::begin_energy_and_force_computation();
+
+	std::fill(_inter_chain_stress_tensor.begin(), _inter_chain_stress_tensor.end(), 0.);
+	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
 }
 
 bool PolymerSwapInteraction::has_custom_stress_tensor() const {

--- a/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.cpp
+++ b/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.cpp
@@ -139,6 +139,15 @@ void PolymerSwapInteraction::begin_energy_computation() {
 	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
 
 	for(int i = 0; i < _N_chains; i++) {
+		for(auto p: CONFIG_INFO->molecules()[i]->particles) {
+			_inter_chain_stress_tensor[0] += SQR(p->vel.x);
+			_inter_chain_stress_tensor[1] += SQR(p->vel.y);
+			_inter_chain_stress_tensor[2] += SQR(p->vel.z);
+			_inter_chain_stress_tensor[3] += p->vel.x * p->vel.y;
+			_inter_chain_stress_tensor[4] += p->vel.x * p->vel.z;
+			_inter_chain_stress_tensor[5] += p->vel.y * p->vel.z;
+		}
+
 		CONFIG_INFO->molecules()[i]->update_com();
 		_chain_coms[i] = CONFIG_INFO->molecules()[i]->com;
 	}

--- a/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.h
+++ b/contrib/rovigatti/src/Interactions/PolymerSwapInteraction.h
@@ -114,6 +114,7 @@ public:
 	virtual void allocate_particles(std::vector<BaseParticle *> &particles);
 
 	void begin_energy_computation() override;
+	void begin_energy_and_force_computation() override;
 
 	bool has_custom_stress_tensor() const override;
 

--- a/contrib/rovigatti/src/Interactions/old/CUDANathanStarInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/old/CUDANathanStarInteraction.cu
@@ -280,8 +280,8 @@ void CUDANathanStarInteraction::_setup_cuda_interp() {
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_bin, &f_copy, sizeof(float)));
 }
 
-void CUDANathanStarInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDANathanStarInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	NathanStarInteraction::init();
 
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_N, &N, sizeof(int)));

--- a/contrib/rovigatti/src/Interactions/old/CUDANathanStarInteraction.h
+++ b/contrib/rovigatti/src/Interactions/old/CUDANathanStarInteraction.h
@@ -26,7 +26,7 @@ public:
 	virtual ~CUDANathanStarInteraction();
 
 	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void cuda_init(int N);
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/contrib/rovigatti/src/Observables/ConstructwisePressure.cpp
+++ b/contrib/rovigatti/src/Observables/ConstructwisePressure.cpp
@@ -106,7 +106,7 @@ void ConstructwisePressure::update_pressure() {
 
 void ConstructwisePressure::update_pressure_PolymerSwap() {
 	PolymerSwapInteraction *interaction = dynamic_cast<PolymerSwapInteraction *>(_config_info->interaction);
-	interaction->begin_energy_computation();
+	interaction->begin_energy_and_force_computation();
 
 	std::vector<LR_vector> forces;
 	forces.reserve(CONFIG_INFO->N());

--- a/contrib/tostiguerra/src/CGNucleicAcidsInteraction.cpp
+++ b/contrib/tostiguerra/src/CGNucleicAcidsInteraction.cpp
@@ -102,6 +102,7 @@ number CGNucleicAcidsInteraction::P_inter_chain() {
 void CGNucleicAcidsInteraction::begin_energy_computation() {
 	BaseInteraction::begin_energy_computation();
 
+	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
 	for(int i = 0; i < _N_chains; i++) {
 		CONFIG_INFO->molecules()[i]->update_com();
 		_chain_coms[i] = CONFIG_INFO->molecules()[i]->com;
@@ -114,7 +115,6 @@ void CGNucleicAcidsInteraction::begin_energy_and_force_computation() {
 	BaseInteraction::begin_energy_and_force_computation();
 
 	std::fill(_inter_chain_stress_tensor.begin(), _inter_chain_stress_tensor.end(), 0.);
-	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
 }
 
 bool CGNucleicAcidsInteraction::has_custom_stress_tensor() const {

--- a/contrib/tostiguerra/src/CGNucleicAcidsInteraction.cpp
+++ b/contrib/tostiguerra/src/CGNucleicAcidsInteraction.cpp
@@ -102,15 +102,19 @@ number CGNucleicAcidsInteraction::P_inter_chain() {
 void CGNucleicAcidsInteraction::begin_energy_computation() {
 	BaseInteraction::begin_energy_computation();
 
-	std::fill(_inter_chain_stress_tensor.begin(), _inter_chain_stress_tensor.end(), 0.);
-	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
-
 	for(int i = 0; i < _N_chains; i++) {
 		CONFIG_INFO->molecules()[i]->update_com();
 		_chain_coms[i] = CONFIG_INFO->molecules()[i]->com;
 	}
 
 	_bonds.clear();
+}
+
+void CGNucleicAcidsInteraction::begin_energy_and_force_computation() {
+	BaseInteraction::begin_energy_and_force_computation();
+
+	std::fill(_inter_chain_stress_tensor.begin(), _inter_chain_stress_tensor.end(), 0.);
+	_chain_coms.resize(_N_chains, LR_vector(0., 0., 0.));
 }
 
 bool CGNucleicAcidsInteraction::has_custom_stress_tensor() const {

--- a/contrib/tostiguerra/src/CGNucleicAcidsInteraction.h
+++ b/contrib/tostiguerra/src/CGNucleicAcidsInteraction.h
@@ -123,6 +123,7 @@ public:
 	virtual void allocate_particles(std::vector<BaseParticle *> &particles);
 
 	void begin_energy_computation() override;
+	void begin_energy_and_force_computation() override;
 
 	bool has_custom_stress_tensor() const override;
 

--- a/docs/source/observables.md
+++ b/docs/source/observables.md
@@ -202,14 +202,16 @@ This observable can be used to save disk space by generating trajectories contai
 Compute the osmotic pressure of the system.
 
 * `type = pressure`: the observable type.
-* `[stress_tensor = <bool>]`: if `true`, the output will contain 7 fields: the total pressure and 6 components of the (symmetric) stress tensor: $xx, yy, zz, xy, xz, yz$.
+* `[stress_tensor = <bool>]`: if `true`, the output will contain 7 fields: the total pressure and 6 components of the (symmetric) stress tensor: $xx, yy, zz, xy, xz, yz$. Defaults to `false`
+* `[PV_only = <bool>]`: if `true`, the pressure and (optionally) the stress tensor won't be divided by the volume of the simulation box. Defaults to `false`.
 
 ## Stress autocorrelation
 
 Compute the stress autocorrelation function $G(t)$ using the multi-tau method describere [here](https://doi.org/10.1063/1.3491098). This observable supports the `update_every` option.
 
-* `[m = int]`: Size of the average used by the algorithm. Defaults to 2.
-* `[p = int]`: The size of the coarse-grained levels used by the algorithm. Defaults to 16.
+* `[m = <int>]`: size of the average used by the algorithm. Defaults to 2.
+* `[p = <int>]`: The size of the coarse-grained levels used by the algorithm. Defaults to 16.
+* `[serialise = <bool>]`: if `true`, every time the observable is printed, also generate files that can be used to recreate the observable's data structures. This makes it possible to restart simulations that keep accumulating statistics for the autocorrelation. Note that if this is set to `true`, then the observable will look for these files to reload the data upon restarting. Defaults to `false`.
 
 ## Pitch
 

--- a/examples/METADYNAMICS/metad_interface.py
+++ b/examples/METADYNAMICS/metad_interface.py
@@ -187,6 +187,9 @@ class Estimator():
             initial_conf = os.path.join(self.base_dir, input_file["conf_file"])
             top_file = os.path.join(self.base_dir, input_file["topology"])
             
+            # remove some clutter from the output
+            input_file["log_file"] = "oxDNA_log.txt"
+            input_file["no_stdout_energy"] = "true"
             input_file["show_overwrite_warnings"] = "false"
             input_file["print_conf_interval"] = str(conf_interval)
             # we standardise the location of the last configuration, which is also the configuration we will start from
@@ -221,6 +224,7 @@ class Estimator():
                     pass
             
             input_file["external_forces_file"] = Estimator.EXT_FORCES_FILE
+            input_file["external_forces"] = "true"
             
             if not self.continue_run:
                 # delete and recreate the bias directory

--- a/src/Backends/FIREBackend.cpp
+++ b/src/Backends/FIREBackend.cpp
@@ -185,7 +185,7 @@ void FIREBackend::_second_step() {
 }
 
 void FIREBackend::_compute_forces() {
-	_interaction->begin_energy_computation();
+	_interaction->begin_energy_and_force_computation();
 
 	_U = (number) 0;
 	for(auto p: _particles) {

--- a/src/Backends/MD_CPUBackend.cpp
+++ b/src/Backends/MD_CPUBackend.cpp
@@ -143,7 +143,7 @@ void MD_CPUBackend::_first_step() {
 }
 
 void MD_CPUBackend::_compute_forces() {
-	_interaction->begin_energy_computation();
+	_interaction->begin_energy_and_force_computation();
 
 	_U = (number) 0;
 	for(auto p : _particles) {

--- a/src/Backends/MD_CPUBackend.cpp
+++ b/src/Backends/MD_CPUBackend.cpp
@@ -16,7 +16,6 @@ MD_CPUBackend::MD_CPUBackend() :
 				MDBackend() {
 	_thermostat = nullptr;
 	_V_move = nullptr;
-	_compute_stress_tensor = false;
 	_stress_tensor_avg_every = -1;
 	_stress_tensor_counter = 0;
 }
@@ -27,15 +26,6 @@ MD_CPUBackend::~MD_CPUBackend() {
 
 void MD_CPUBackend::get_settings(input_file &inp) {
 	MDBackend::get_settings(inp);
-
-	getInputBool(&inp, "MD_compute_stress_tensor", &_compute_stress_tensor, 0);
-	if(_compute_stress_tensor) {
-		OX_LOG(Logger::LOG_INFO, "Computing the stress tensor directly in the backend");
-		getInputInt(&inp, "MD_stress_tensor_avg_every", &_stress_tensor_avg_every, 1);
-		if(_stress_tensor_avg_every < 1) {
-			throw oxDNAException("MD_stress_tensor_avg_every should be larger than 0");
-		}
-	}
 
 	if(_use_barostat) {
 		std::string move_name("volume");
@@ -72,12 +62,6 @@ void MD_CPUBackend::init() {
 	}
 
 	_compute_forces();
-	if(_compute_stress_tensor) {
-		for(auto p : _particles) {
-			_update_kinetic_stress_tensor(p);
-		}
-		_update_backend_info();
-	}
 }
 
 void MD_CPUBackend::_first_step() {
@@ -170,12 +154,7 @@ void MD_CPUBackend::_compute_forces() {
 		}
 
 		for(auto q : _lists->get_neigh_list(p)) {
-			if(!_compute_stress_tensor) {
-				_U += _interaction->pair_interaction_nonbonded(p, q, true, true);
-			}
-			else {
-				_update_forces_and_stress_tensor(p, q);
-			}
+			_U += _interaction->pair_interaction_nonbonded(p, q, true, true);
 		}
 	}
 }
@@ -190,68 +169,11 @@ void MD_CPUBackend::_second_step() {
 		if(p->is_rigid_body()) {
 			p->L += p->torque * _dt * (number) 0.5f;
 		}
-
-		if(_compute_stress_tensor) {
-			_update_kinetic_stress_tensor(p);
-		}
 	}
-}
-
-void MD_CPUBackend::_update_forces_and_stress_tensor(BaseParticle *p, BaseParticle *q) {
-	// pair_interaction_nonbonded will change these vectors, but we still need them in the next
-	// first integration step. For this reason we copy and then restore their values
-	// after the calculation
-	LR_vector old_p_force(p->force);
-	LR_vector old_q_force(q->force);
-	LR_vector old_p_torque(p->torque);
-	LR_vector old_q_torque(q->torque);
-
-	p->force = q->force = p->torque = q->torque = LR_vector();
-
-	LR_vector r = _box->min_image(p->pos, q->pos);
-	_interaction->set_computed_r(r);
-	_interaction->pair_interaction_nonbonded(p, q, false, true);
-
-	_stress_tensor.v1.x += r.x * q->force.x;
-	_stress_tensor.v1.y += r.x * q->force.y;
-	_stress_tensor.v1.z += r.x * q->force.z;
-	_stress_tensor.v2.x += r.y * q->force.x;
-	_stress_tensor.v2.y += r.y * q->force.y;
-	_stress_tensor.v2.z += r.y * q->force.z;
-	_stress_tensor.v3.x += r.z * q->force.x;
-	_stress_tensor.v3.y += r.z * q->force.y;
-	_stress_tensor.v3.z += r.z * q->force.z;
-
-	p->force += old_p_force;
-	q->force += old_q_force;
-	p->torque += old_p_torque;
-	q->torque += old_q_torque;
-}
-
-void MD_CPUBackend::_update_kinetic_stress_tensor(BaseParticle *p) {
-	LR_vector vel = p->vel;
-	if(_shear_rate > 0.) {
-		number Ly = _box->box_sides().y;
-		number y_in_box = p->pos.y - floor(p->pos.y / Ly) * Ly - 0.5 * Ly;
-		number flow_vx = y_in_box * _shear_rate;
-		vel.x -= flow_vx;
-	}
-	_stress_tensor.v1.x += SQR(vel.x);
-	_stress_tensor.v1.y += vel.x * vel.y;
-	_stress_tensor.v1.z += vel.x * vel.z;
-	_stress_tensor.v2.x += vel.y * vel.x;
-	_stress_tensor.v2.y += SQR(vel.y);
-	_stress_tensor.v2.z += vel.y * vel.z;
-	_stress_tensor.v3.x += vel.z * vel.x;
-	_stress_tensor.v3.y += vel.z * vel.y;
-	_stress_tensor.v3.z += SQR(vel.z);
 }
 
 void MD_CPUBackend::_update_backend_info() {
-	_stress_tensor /= 3 * _box->V();
-	double P = _stress_tensor.v1.x + _stress_tensor.v2.y + _stress_tensor.v3.z;
-	_backend_info = Utils::sformat("% 10.6lf % 10.6lf % 10.6lf % 10.6lf % 10.6lf % 10.6lf % 10.6lf % 10.6lf % 10.6lf % 10.6lf", P, _stress_tensor.v1.x, _stress_tensor.v1.y, _stress_tensor.v1.z, _stress_tensor.v2.x, _stress_tensor.v2.y, _stress_tensor.v2.z, _stress_tensor.v3.x, _stress_tensor.v3.y, _stress_tensor.v3.z);
-	_stress_tensor = LR_matrix();
+
 }
 
 void MD_CPUBackend::sim_step() {
@@ -278,15 +200,6 @@ void MD_CPUBackend::sim_step() {
 	_timer_forces->resume();
 	_compute_forces();
 	_second_step();
-
-	if(_compute_stress_tensor) {
-		_stress_tensor_counter++;
-		if(_stress_tensor_counter == _stress_tensor_avg_every) {
-			_stress_tensor_counter = 0;
-			_stress_tensor /= _stress_tensor_avg_every;
-			_update_backend_info();
-		}
-	}
 
 	_timer_forces->pause();
 

--- a/src/Backends/MD_CPUBackend.h
+++ b/src/Backends/MD_CPUBackend.h
@@ -22,10 +22,8 @@ class MD_CPUBackend: public MDBackend {
 protected:
 	std::shared_ptr<BaseThermostat> _thermostat;
 	MovePtr _V_move;
-	bool _compute_stress_tensor;
 	int _stress_tensor_avg_every;
 	int _stress_tensor_counter;
-	LR_matrix _stress_tensor;
 
 	// thermostat introduced in https://journals.aps.org/pre/abstract/10.1103/PhysRevE.75.056707
 	bool _use_builtin_langevin_thermostat = false;
@@ -36,8 +34,6 @@ protected:
 	void _compute_forces();
 	void _second_step();
 
-	void _update_forces_and_stress_tensor(BaseParticle *p, BaseParticle *q);
-	void _update_kinetic_stress_tensor(BaseParticle *p);
 	void _update_backend_info();
 
 public:

--- a/src/Backends/MinBackend.cpp
+++ b/src/Backends/MinBackend.cpp
@@ -37,7 +37,7 @@ void MinBackend::init() {
 }
 
 void MinBackend::_compute_forces() {
-	_interaction->begin_energy_computation();
+	_interaction->begin_energy_and_force_computation();
 
 	_U = (number) 0;
 	for(auto p: _particles) {

--- a/src/Backends/SimBackend.cpp
+++ b/src/Backends/SimBackend.cpp
@@ -608,7 +608,7 @@ void SimBackend::update_observables_data() {
 	bool updated = false;
 	for(auto const &obs : _config_info->observables) {
 		if(obs->need_updating(current_step())) {
-			if(!updated) {
+			if(!updated && obs->require_data_on_CPU()) {
 				apply_simulation_data_changes();
 				updated = true;
 			}

--- a/src/Backends/SimBackend.cpp
+++ b/src/Backends/SimBackend.cpp
@@ -729,6 +729,11 @@ void SimBackend::print_conf(bool reduced, bool only_last) {
 		if(_obs_output_last_conf_bin != nullptr) {
 			_obs_output_last_conf_bin->print_output(current_step());
 		}
+
+		// serialise the observables
+		for(auto const &obs : _config_info->observables) {
+			obs->serialise();
+		}
 	}
 }
 

--- a/src/CUDA/Backends/CUDABaseBackend.cu
+++ b/src/CUDA/Backends/CUDABaseBackend.cu
@@ -195,7 +195,7 @@ void CUDABaseBackend::init_cuda() {
 	int N = CONFIG_INFO->N();
 	_h_cuda_box.set_CUDA_from_CPU(CONFIG_INFO->box);
 
-	_cuda_interaction->cuda_init(box_side, N);
+	_cuda_interaction->cuda_init(N);
 
 	_vec_size = sizeof(c_number4) * N;
 	_orient_size = sizeof(GPU_quat) * N;

--- a/src/CUDA/Backends/CUDA_mixed.cuh
+++ b/src/CUDA/Backends/CUDA_mixed.cuh
@@ -20,7 +20,10 @@ __device__ GPU_quat_double _get_updated_orientation(LR_double4 &L, GPU_quat_doub
 	return quat_multiply(old_o, R);
 }
 
-__global__ void first_step_mixed(float4 *poss, GPU_quat *orientations, LR_double4 *possd, GPU_quat_double *orientationsd, float4 *list_poss, LR_double4 *velsd, LR_double4 *Lsd, float4 *forces, float4 *torques, bool *are_lists_old, bool any_rigid_body) {
+__global__ void first_step_mixed(float4 __restrict__ *poss, GPU_quat __restrict__ *orientations, LR_double4 __restrict__ *possd,
+		GPU_quat_double __restrict__ *orientationsd, const float4 __restrict__ *list_poss, LR_double4 __restrict__ *velsd,
+		LR_double4 __restrict__ *Lsd, const float4 __restrict__ *forces, const float4 __restrict__ *torques,
+		bool *are_lists_old, bool any_rigid_body) {
 	if(IND >= MD_N[0]) return;
 
 	float4 F = forces[IND];

--- a/src/CUDA/Backends/MD_CUDABackend.cu
+++ b/src/CUDA/Backends/MD_CUDABackend.cu
@@ -717,6 +717,10 @@ void MD_CUDABackend::init() {
 	_cuda_lists->update(_d_poss, _d_list_poss, _d_bonds);
 	_set_external_forces();
 	_cuda_interaction->compute_forces(_cuda_lists, _d_poss, _d_orientations, _d_forces, _d_torques, _d_bonds, _d_cuda_box);
+
+	if(_update_st_every > 0) {
+		_interaction->set_stress_tensor(_cuda_interaction->CPU_stress_tensor(_d_vels));
+	}
 }
 
 #pragma GCC diagnostic pop

--- a/src/CUDA/Backends/MD_CUDABackend.cu
+++ b/src/CUDA/Backends/MD_CUDABackend.cu
@@ -576,6 +576,11 @@ void MD_CUDABackend::sim_step() {
 		c_number energy = GpuUtils::sum_c_number4_to_double_on_GPU(_d_forces, N());
 		_backend_info = Utils::sformat("\tCUDA_energy: %lf", energy / (2. * N()));
 	}
+
+	if(_update_st_every > 0 && (CONFIG_INFO->curr_step % _update_st_every == 0)) {
+		_interaction->set_stress_tensor(_cuda_interaction->CPU_stress_tensor(_d_vels));
+	}
+
 	_timer_forces->pause();
 
 	_timer_thermostat->resume();
@@ -601,6 +606,7 @@ void MD_CUDABackend::get_settings(input_file &inp) {
 	getInputBool(&inp, "CUDA_avoid_cpu_calculations", &_avoid_cpu_calculations, 0);
 	getInputBool(&inp, "CUDA_barostat_always_refresh", &_cuda_barostat_always_refresh, 0);
 	getInputBool(&inp, "CUDA_print_energy", &_print_energy, 0);
+	getInputInt(&inp, "CUDA_update_stress_tensor_every", &_update_st_every, 0);
 
 	_cuda_thermostat = CUDAThermostatFactory::make_thermostat(inp, _box.get());
 	_cuda_thermostat->get_settings(inp);

--- a/src/CUDA/Backends/MD_CUDABackend.h
+++ b/src/CUDA/Backends/MD_CUDABackend.h
@@ -48,6 +48,7 @@ protected:
 	c_number4 *_d_buff_vels, *_d_buff_Ls;
 
 	llint _barostat_attempts, _barostat_accepted;
+	int _update_st_every = 0;
 
 	bool _print_energy;
 

--- a/src/CUDA/Interactions/CUDABaseInteraction.cu
+++ b/src/CUDA/Interactions/CUDABaseInteraction.cu
@@ -108,7 +108,9 @@ void CUDABaseInteraction::cuda_init(int N) {
 		CUDA_SAFE_CALL(cudaMemset(_d_edge_torques, 0, size));
 	}
 
-	CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc(&_d_st, N * sizeof(CUDAStressTensor)));
+	if(_update_st) {
+		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc(&_d_st, N * sizeof(CUDAStressTensor)));
+	}
 }
 
 void CUDABaseInteraction::set_launch_cfg(CUDA_kernel_cfg &launch_cfg) {

--- a/src/CUDA/Interactions/CUDABaseInteraction.cu
+++ b/src/CUDA/Interactions/CUDABaseInteraction.cu
@@ -81,19 +81,21 @@ void CUDABaseInteraction::_sum_edge_forces_torques(c_number4 *d_forces, c_number
 }
 
 void CUDABaseInteraction::get_cuda_settings(input_file &inp) {
-	int tmpi;
-	if(getInputBoolAsInt(&inp, "use_edge", &tmpi, 0) == KEY_FOUND) {
-		if(tmpi > 0) {
-			_use_edge = true;
-			getInputInt(&inp, "edge_n_forces", &_n_forces, 0);
-			if(_n_forces < 1) throw oxDNAException("edge_n_forces must be > 0");
+	getInputBool(&inp, "use_edge", &_use_edge, 0);
+	if(_use_edge) {
+		if(!_edge_compatible) {
+			throw oxDNAException("The selected CUDA interaction is not compatible with 'use_edge = true'");
+		}
+
+		getInputInt(&inp, "edge_n_forces", &_n_forces, 0);
+		if(_n_forces < 1) {
+			throw oxDNAException("edge_n_forces must be > 0");
 		}
 	}
 }
 
-void CUDABaseInteraction::cuda_init(c_number box_side, int N) {
+void CUDABaseInteraction::cuda_init(int N) {
 	_N = N;
-	_box_side = box_side;
 
 	if(_use_edge && _d_edge_forces == nullptr) {
 		size_t size = sizeof(c_number4) * _N * _n_forces;

--- a/src/CUDA/Interactions/CUDABaseInteraction.cu
+++ b/src/CUDA/Interactions/CUDABaseInteraction.cu
@@ -18,42 +18,30 @@
 #include <thrust/reduce.h>
 #include <thrust/transform_reduce.h>
 
-__global__ void sum_edge_forces_torques(c_number4 *edge_forces, c_number4 *forces, c_number4 *edge_torques, c_number4 *torques, int N, int n_forces) {
+__global__ void sum_edge_forces_torques(c_number4 __restrict__ *edge_forces, c_number4 __restrict__ *forces, c_number4 __restrict__ *edge_torques,
+		c_number4 __restrict__ *torques, int N, int n_forces) {
 	if(IND >= N) return;
 
 	c_number4 tot_force = forces[IND];
 	c_number4 tot_torque = torques[IND];
 	for(int i = 0; i < n_forces; i++) {
-		c_number4 tmp_force = edge_forces[N * i + IND];
-		tot_force.x += tmp_force.x;
-		tot_force.y += tmp_force.y;
-		tot_force.z += tmp_force.z;
-		tot_force.w += tmp_force.w;
-		edge_forces[N * i + IND] = make_c_number4(0, 0, 0, 0);
-
-		c_number4 tmp_torque = edge_torques[N * i + IND];
-		tot_torque.x += tmp_torque.x;
-		tot_torque.y += tmp_torque.y;
-		tot_torque.z += tmp_torque.z;
-		tot_torque.w += tmp_torque.w;
-		edge_torques[N * i + IND] = make_c_number4(0, 0, 0, 0);
+		tot_force += edge_forces[N * i + IND];
+		tot_torque += edge_torques[N * i + IND];
+		edge_forces[N * i + IND] = make_c_number4(0.f, 0.f, 0.f, 0.f);
+		edge_torques[N * i + IND] = make_c_number4(0.f, 0.f, 0.f, 0.f);
 	}
 
 	forces[IND] = tot_force;
 	torques[IND] = tot_torque;
 }
 
-__global__ void sum_edge_forces(c_number4 *edge_forces, c_number4 *forces, int N, int n_forces) {
+__global__ void sum_edge_forces(c_number4 __restrict__ *edge_forces, c_number4 __restrict__ *forces, int N, int n_forces) {
 	if(IND >= N) return;
 
 	c_number4 tot_force = forces[IND];
 	for(int i = 0; i < n_forces; i++) {
-		c_number4 tmp_force = edge_forces[N * i + IND];
-		tot_force.x += tmp_force.x;
-		tot_force.y += tmp_force.y;
-		tot_force.z += tmp_force.z;
-		tot_force.w += tmp_force.w;
-		edge_forces[N * i + IND] = make_c_number4(0, 0, 0, 0);
+		tot_force += edge_forces[N * i + IND];
+		edge_forces[N * i + IND] = make_c_number4(0.f, 0.f, 0.f, 0.f);
 	}
 
 	forces[IND] = tot_force;

--- a/src/CUDA/Interactions/CUDABaseInteraction.cu
+++ b/src/CUDA/Interactions/CUDABaseInteraction.cu
@@ -77,6 +77,12 @@ void CUDABaseInteraction::_sum_edge_forces_torques(c_number4 *d_forces, c_number
 }
 
 void CUDABaseInteraction::get_cuda_settings(input_file &inp) {
+	int update_st_every = 0;
+	getInputInt(&inp, "CUDA_update_stress_tensor_every", &update_st_every, 0);
+	if(update_st_every > 0) {
+		_update_st = true;
+	}
+
 	getInputBool(&inp, "use_edge", &_use_edge, 0);
 	if(_use_edge) {
 		if(!_edge_compatible) {

--- a/src/CUDA/Interactions/CUDABaseInteraction.h
+++ b/src/CUDA/Interactions/CUDABaseInteraction.h
@@ -27,6 +27,7 @@ protected:
 	CUDA_kernel_cfg _ffs_hb_eval_kernel_cfg;
 	CUDA_kernel_cfg _ffs_dist_eval_kernel_cfg;
 
+	bool _update_st = false;
 	CUDAStressTensor *_d_st = nullptr, *_h_st = nullptr;
 
 	int _N = -1;

--- a/src/CUDA/Interactions/CUDABaseInteraction.h
+++ b/src/CUDA/Interactions/CUDABaseInteraction.h
@@ -15,23 +15,24 @@
 /**
  * @brief Abstract class providing an interface for CUDA-based interactions.
  */
-
 class CUDABaseInteraction {
 protected:
 	bool _use_edge = false;
 	bool _edge_compatible = false;
 	/// c_number of force slots per particle. Used only if _use_edge == true.
-	int _n_forces;
+	int _n_forces = 1;
 	CUDA_kernel_cfg _launch_cfg;
 	CUDA_kernel_cfg _ffs_hb_precalc_kernel_cfg;
 	CUDA_kernel_cfg _ffs_dist_precalc_kernel_cfg;
 	CUDA_kernel_cfg _ffs_hb_eval_kernel_cfg;
 	CUDA_kernel_cfg _ffs_dist_eval_kernel_cfg;
 
-	int _N;
+	CUDAStressTensor *_d_st = nullptr, *_h_st = nullptr;
 
-	c_number4 *_d_edge_forces;
-	c_number4 *_d_edge_torques;
+	int _N = -1;
+
+	c_number4 *_d_edge_forces = nullptr;
+	c_number4 *_d_edge_torques = nullptr;
 
 	virtual void _sum_edge_forces(c_number4 *d_forces);
 	virtual void _sum_edge_forces_torques(c_number4 *d_forces, c_number4 *d_torques);
@@ -47,9 +48,11 @@ public:
 	virtual void sync_host() {}
 	virtual void sync_GPU() {}
 
+	virtual StressTensor CPU_stress_tensor(c_number4 *vels);
+
 	void set_launch_cfg(CUDA_kernel_cfg &launch_cfg);
 
-	virtual void compute_forces(CUDABaseList*lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box) = 0;
+	virtual void compute_forces(CUDABaseList *lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox *d_box) = 0;
 	virtual void _hb_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op_pairs1, int *op_pairs2, float *hb_energies, int n_threads, bool *region_is_nearhb, CUDA_kernel_cfg hb_kernel_cfg, CUDABox*d_box);
 	virtual void _near_hb_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op_pairs1, int *op_pairs2, bool *nearly_bonded_array, int n_threads, bool *region_is_nearhb, CUDA_kernel_cfg hb_kernel_cfg, CUDABox*d_box);
 	virtual void _dist_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op_pairs1, int *op_pairs2, c_number *op_dists, int n_threads, CUDA_kernel_cfg dist_kernel_cfg, CUDABox*d_box);

--- a/src/CUDA/Interactions/CUDABaseInteraction.h
+++ b/src/CUDA/Interactions/CUDABaseInteraction.h
@@ -18,7 +18,8 @@
 
 class CUDABaseInteraction {
 protected:
-	bool _use_edge;
+	bool _use_edge = false;
+	bool _edge_compatible = false;
 	/// c_number of force slots per particle. Used only if _use_edge == true.
 	int _n_forces;
 	CUDA_kernel_cfg _launch_cfg;
@@ -28,7 +29,6 @@ protected:
 	CUDA_kernel_cfg _ffs_dist_eval_kernel_cfg;
 
 	int _N;
-	c_number _box_side;
 
 	c_number4 *_d_edge_forces;
 	c_number4 *_d_edge_torques;
@@ -41,7 +41,7 @@ public:
 
 	virtual void get_settings(input_file &inp) = 0;
 	virtual void get_cuda_settings(input_file &inp);
-	virtual void cuda_init(c_number box_side, int N);
+	virtual void cuda_init(int N);
 	virtual c_number get_cuda_rcut() = 0;
 
 	virtual void sync_host() {}

--- a/src/CUDA/Interactions/CUDADNAInteraction.cu
+++ b/src/CUDA/Interactions/CUDADNAInteraction.cu
@@ -157,7 +157,8 @@ void CUDADNAInteraction::compute_forces(CUDABaseList*lists, c_number4 *d_poss, G
 	if(_use_edge) {
 		dna_forces_edge_nonbonded
 			<<<(lists->N_edges - 1)/(_launch_cfg.threads_per_block) + 1, _launch_cfg.threads_per_block>>>
-			(d_poss, d_orientations, _d_edge_forces, _d_edge_torques, lists->d_edge_list, lists->N_edges, d_bonds, _grooving, _use_debye_huckel, _use_oxDNA2_coaxial_stacking, d_box);
+			(d_poss, d_orientations, _d_edge_forces, _d_edge_torques, lists->d_edge_list, lists->N_edges, d_bonds,
+			_grooving, _use_debye_huckel, _use_oxDNA2_coaxial_stacking, _d_st, d_box);
 
 		_sum_edge_forces_torques(d_forces, d_torques);
 
@@ -165,12 +166,15 @@ void CUDADNAInteraction::compute_forces(CUDABaseList*lists, c_number4 *d_poss, G
 
 		dna_forces_edge_bonded
 			<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-			(d_poss, d_orientations, d_forces, d_torques, d_bonds, _grooving, _use_oxDNA2_FENE, _use_mbf, _mbf_xmax, _mbf_finf);
+			(d_poss, d_orientations, d_forces, d_torques, d_bonds, _grooving, _use_oxDNA2_FENE, _use_mbf, _mbf_xmax,
+			_mbf_finf, _d_st);
 	}
 	else {
 		dna_forces
 			<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-			(d_poss, d_orientations, d_forces, d_torques, lists->d_matrix_neighs, lists->d_number_neighs, d_bonds, _grooving, _use_debye_huckel, _use_oxDNA2_coaxial_stacking, _use_oxDNA2_FENE, this->_use_mbf, this->_mbf_xmax, this->_mbf_finf, d_box);
+			(d_poss, d_orientations, d_forces, d_torques, lists->d_matrix_neighs, lists->d_number_neighs,
+			d_bonds, _grooving, _use_debye_huckel, _use_oxDNA2_coaxial_stacking, _use_oxDNA2_FENE, _use_mbf,
+			_mbf_xmax, _mbf_finf, _d_st, d_box);
 		CUT_CHECK_ERROR("forces_second_step simple_lists error");
 	}
 }

--- a/src/CUDA/Interactions/CUDADNAInteraction.cu
+++ b/src/CUDA/Interactions/CUDADNAInteraction.cu
@@ -130,7 +130,7 @@ void CUDADNAInteraction::cuda_init(int N) {
 
 		c_number debyecut;
 		if(this->_grooving) {
-			debyecut = 2.0f * sqrt((POS_MM_BACK1) * (POS_MM_BACK1) + (POS_MM_BACK2) * (POS_MM_BACK2)) + _debye_huckel_RC;
+			debyecut = 2.0f * sqrt(SQR(POS_MM_BACK1) + SQR(POS_MM_BACK2)) + _debye_huckel_RC;
 		}
 		else {
 			debyecut = 2.0f * sqrt(SQR(POS_BACK)) + _debye_huckel_RC;
@@ -157,7 +157,7 @@ void CUDADNAInteraction::_on_T_update() {
 
 void CUDADNAInteraction::_init_strand_ends(LR_bonds *d_bonds) {
 	CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<int>(&_d_is_strand_end, sizeof(int) * _N));
-	init_strand_ends<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>(_d_is_strand_end, d_bonds);
+	init_DNA_strand_ends<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>(_d_is_strand_end, d_bonds, _N);
 }
 
 void CUDADNAInteraction::compute_forces(CUDABaseList *lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box) {

--- a/src/CUDA/Interactions/CUDADNAInteraction.cu
+++ b/src/CUDA/Interactions/CUDADNAInteraction.cu
@@ -14,6 +14,9 @@
 
 CUDADNAInteraction::CUDADNAInteraction() {
 	_edge_compatible = true;
+	_use_debye_huckel = false;
+	_use_oxDNA2_coaxial_stacking = false;
+	_use_oxDNA2_FENE = false;
 }
 
 CUDADNAInteraction::~CUDADNAInteraction() {
@@ -21,9 +24,6 @@ CUDADNAInteraction::~CUDADNAInteraction() {
 }
 
 void CUDADNAInteraction::get_settings(input_file &inp) {
-	_use_debye_huckel = false;
-	_use_oxDNA2_coaxial_stacking = false;
-	_use_oxDNA2_FENE = false;
 	std::string inter_type;
 	if(getInputString(&inp, "interaction_type", inter_type, 0) == KEY_FOUND) {
 		if(inter_type.compare("DNA2") == 0) {
@@ -154,6 +154,8 @@ void CUDADNAInteraction::_on_T_update() {
 }
 
 void CUDADNAInteraction::compute_forces(CUDABaseList*lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box) {
+	CUDA_SAFE_CALL(cudaMemset(_d_st, 0, _N * sizeof(CUDAStressTensor)));
+
 	if(_use_edge) {
 		dna_forces_edge_nonbonded
 			<<<(lists->N_edges - 1)/(_launch_cfg.threads_per_block) + 1, _launch_cfg.threads_per_block>>>

--- a/src/CUDA/Interactions/CUDADNAInteraction.cu
+++ b/src/CUDA/Interactions/CUDADNAInteraction.cu
@@ -165,7 +165,9 @@ void CUDADNAInteraction::compute_forces(CUDABaseList *lists, c_number4 *d_poss, 
 		_init_strand_ends(d_bonds);
 	}
 
-	CUDA_SAFE_CALL(cudaMemset(_d_st, 0, _N * sizeof(CUDAStressTensor)));
+	if(_update_st) {
+		CUDA_SAFE_CALL(cudaMemset(_d_st, 0, _N * sizeof(CUDAStressTensor)));
+	}
 
 	if(_use_edge) {
 		if(_n_forces == 1) { // we can directly use d_forces and d_torques so that no sum is required

--- a/src/CUDA/Interactions/CUDADNAInteraction.h
+++ b/src/CUDA/Interactions/CUDADNAInteraction.h
@@ -39,8 +39,8 @@ public:
 	float _minus_kappa;
 	// End copy from DNA2Interaction.h
 
-	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void get_settings(input_file &inp) override;
+	void cuda_init(int N) override;
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/src/CUDA/Interactions/CUDADNAInteraction.h
+++ b/src/CUDA/Interactions/CUDADNAInteraction.h
@@ -38,6 +38,7 @@ public:
 	float _debye_huckel_B; // prefactor of the quadratic cut-off
 	float _minus_kappa;
 	// End copy from DNA2Interaction.h
+	int *_d_is_strand_end = nullptr;
 
 	void get_settings(input_file &inp) override;
 	void cuda_init(int N) override;
@@ -45,12 +46,14 @@ public:
 		return this->get_rcut();
 	}
 
-	void _on_T_update() override;
-
 	void compute_forces(CUDABaseList*lists, c_number4 *d_poss, GPU_quat *d_qorientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box);
 	void _hb_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op_pairs1, int *op_pairs2, float *hb_energies, int n_threads, bool *region_is_nearhb, CUDA_kernel_cfg hb_kernel_cfg, CUDABox*d_box);
 	void _near_hb_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op_pairs1, int *op_pairs2, bool *nearly_bonded_array, int n_threads, bool *region_is_nearhb, CUDA_kernel_cfg hb_kernel_cfg, CUDABox*d_box);
 	void _dist_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op_pairs1, int *op_pairs2, c_number *op_dists, int n_threads, CUDA_kernel_cfg dist_kernel_cfg, CUDABox*d_box);
+
+protected:
+	void _on_T_update() override;
+	void _init_strand_ends(LR_bonds *d_bonds);
 };
 
 #endif /* CUDADNAINTERACTION_H_ */

--- a/src/CUDA/Interactions/CUDALJInteraction.cu
+++ b/src/CUDA/Interactions/CUDALJInteraction.cu
@@ -41,29 +41,18 @@ void CUDALJInteraction::cuda_init(c_number box_side, int N) {
 }
 
 void CUDALJInteraction::compute_forces(CUDABaseList*lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box) {
-	CUDASimpleVerletList*_v_lists = dynamic_cast<CUDASimpleVerletList*>(lists);
-	if(_v_lists != NULL) {
-		if(_v_lists->use_edge()) {
-			lj_forces_edge
-				<<<(_v_lists->N_edges - 1)/(this->_launch_cfg.threads_per_block) + 1, this->_launch_cfg.threads_per_block>>>
-				(d_poss, this->_d_edge_forces, _v_lists->d_edge_list, _v_lists->N_edges, d_box);
+	if(_use_edge) {
+		lj_forces_edge
+			<<<(lists->N_edges - 1)/(this->_launch_cfg.threads_per_block) + 1, this->_launch_cfg.threads_per_block>>>
+			(d_poss, _d_edge_forces, lists->d_edge_list, lists->N_edges, d_box);
 
-			this->_sum_edge_forces(d_forces);
-			CUT_CHECK_ERROR("forces_second_step error -- lj");
-		}
-		else {
-			lj_forces
-				<<<this->_launch_cfg.blocks, this->_launch_cfg.threads_per_block>>>
-				(d_poss, d_forces, _v_lists->d_matrix_neighs, _v_lists->d_number_neighs, d_box);
-			CUT_CHECK_ERROR("forces_second_step lj simple_lists error");
-		}
+		this->_sum_edge_forces(d_forces);
+		CUT_CHECK_ERROR("forces_second_step error -- lj");
 	}
-
-	CUDANoList*_no_lists = dynamic_cast<CUDANoList*>(lists);
-	if(_no_lists != NULL) {
+	else {
 		lj_forces
 			<<<this->_launch_cfg.blocks, this->_launch_cfg.threads_per_block>>>
-			(d_poss, d_forces, d_box);
-		CUT_CHECK_ERROR("forces_second_step lj no_lists error");
+			(d_poss, d_forces, lists->d_matrix_neighs, lists->d_number_neighs, d_box);
+		CUT_CHECK_ERROR("forces_second_step lj simple_lists error");
 	}
 }

--- a/src/CUDA/Interactions/CUDALJInteraction.cu
+++ b/src/CUDA/Interactions/CUDALJInteraction.cu
@@ -12,7 +12,7 @@
 #include "../Lists/CUDANoList.h"
 
 CUDALJInteraction::CUDALJInteraction() {
-
+	_edge_compatible = true;
 }
 
 CUDALJInteraction::~CUDALJInteraction() {
@@ -23,8 +23,8 @@ void CUDALJInteraction::get_settings(input_file &inp) {
 	LJInteraction::get_settings(inp);
 }
 
-void CUDALJInteraction::cuda_init(c_number box_side, int N) {
-	CUDABaseInteraction::cuda_init(box_side, N);
+void CUDALJInteraction::cuda_init(int N) {
+	CUDABaseInteraction::cuda_init(N);
 	LJInteraction::init();
 
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_N, &N, sizeof(int)));

--- a/src/CUDA/Interactions/CUDALJInteraction.h
+++ b/src/CUDA/Interactions/CUDALJInteraction.h
@@ -20,8 +20,8 @@ public:
 	CUDALJInteraction();
 	virtual ~CUDALJInteraction();
 
-	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void get_settings(input_file &inp) override;
+	void cuda_init(int N) override;
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/src/CUDA/Interactions/CUDAPatchyInteraction.h
+++ b/src/CUDA/Interactions/CUDAPatchyInteraction.h
@@ -22,8 +22,8 @@ public:
 	CUDAPatchyInteraction();
 	virtual ~CUDAPatchyInteraction();
 
-	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void get_settings(input_file &inp) override;
+	void cuda_init(int N) override;
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/src/CUDA/Interactions/CUDARNAInteraction.cu
+++ b/src/CUDA/Interactions/CUDARNAInteraction.cu
@@ -223,7 +223,9 @@ CUDARNAInteraction::CUDARNAInteraction() {
 }
 
 CUDARNAInteraction::~CUDARNAInteraction() {
-
+	if(_d_is_strand_end != nullptr) {
+		CUDA_SAFE_CALL(cudaFree(_d_is_strand_end));
+	}
 }
 
 void CUDARNAInteraction::get_settings(input_file &inp) {
@@ -235,7 +237,7 @@ void CUDARNAInteraction::get_settings(input_file &inp) {
 			_use_debye_huckel = true;
 			// copy-pasted from the DNA2Interaction constructor
 			_debye_huckel_half_charged_ends = true;
-			this->_grooving = true;
+			_grooving = true;
 			// end copy from DNA2Interaction
 
 			// copied from DNA2Interaction::get_settings() (CPU), the least bad way of doing things
@@ -253,15 +255,15 @@ void CUDARNAInteraction::get_settings(input_file &inp) {
 
 			int mismatches = 0;
 			if(getInputBoolAsInt(&inp, "mismatch_repulsion", &mismatches, 0) == KEY_FOUND) {
-				this->_mismatch_repulsion = (bool) mismatches;
+				_mismatch_repulsion = (bool) mismatches;
 			}
-			if(this->_mismatch_repulsion) {
+			if(_mismatch_repulsion) {
 				float temp;
 				if(getInputFloat(&inp, "mismatch_repulsion_strength", &temp, 0) == KEY_FOUND) {
-					this->_RNA_HYDR_MIS = temp;
+					_RNA_HYDR_MIS = temp;
 				}
 				else {
-					this->_RNA_HYDR_MIS = 1;
+					_RNA_HYDR_MIS = 1;
 				}
 
 			}
@@ -276,23 +278,23 @@ void CUDARNAInteraction::cuda_init(int N) {
 	CUDABaseInteraction::cuda_init(N);
 	RNAInteraction::init();
 
-	float f_copy = 1.0; //this->_hb_multiplier;
+	float f_copy = 1.0; //_hb_multiplier;
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_hb_multi, &f_copy, sizeof(float)));
 
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_N, &N, sizeof(int)));
 
 	//mismatch repulsion modification
-	if(this->_mismatch_repulsion) {
-		float tempmis = -1.0 * this->_RNA_HYDR_MIS / this->model->RNA_HYDR_EPS;
-		this->F1_EPS[RNA_HYDR_F1][0][0] *= tempmis;
-		this->F1_SHIFT[RNA_HYDR_F1][0][0] *= tempmis;
+	if(_mismatch_repulsion) {
+		float tempmis = -1.0 * _RNA_HYDR_MIS / model->RNA_HYDR_EPS;
+		F1_EPS[RNA_HYDR_F1][0][0] *= tempmis;
+		F1_SHIFT[RNA_HYDR_F1][0][0] *= tempmis;
 	}
 
 	c_number tmp[50];
 	for(int i = 0; i < 2; i++) {
 		for(int j = 0; j < 5; j++) {
 			for(int k = 0; k < 5; k++) {
-				tmp[i * 25 + j * 5 + k] = this->F1_EPS[i][j][k];
+				tmp[i * 25 + j * 5 + k] = F1_EPS[i][j][k];
 			}
 		}
 	}
@@ -302,47 +304,47 @@ void CUDARNAInteraction::cuda_init(int N) {
 	for(int i = 0; i < 2; i++) {
 		for(int j = 0; j < 5; j++) {
 			for(int k = 0; k < 5; k++) {
-				tmp[i * 25 + j * 5 + k] = this->F1_SHIFT[i][j][k];
+				tmp[i * 25 + j * 5 + k] = F1_SHIFT[i][j][k];
 			}
 		}
 	}
 
 	COPY_ARRAY_TO_CONSTANT(MD_F1_SHIFT, tmp, 50);
 
-	COPY_ARRAY_TO_CONSTANT(MD_F1_A, this->F1_A, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_RC, this->F1_RC, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_R0, this->F1_R0, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_BLOW, this->F1_BLOW, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_BHIGH, this->F1_BHIGH, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_RLOW, this->F1_RLOW, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_RHIGH, this->F1_RHIGH, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_RCLOW, this->F1_RCLOW, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F1_RCHIGH, this->F1_RCHIGH, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_A, F1_A, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_RC, F1_RC, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_R0, F1_R0, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_BLOW, F1_BLOW, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_BHIGH, F1_BHIGH, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_RLOW, F1_RLOW, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_RHIGH, F1_RHIGH, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_RCLOW, F1_RCLOW, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F1_RCHIGH, F1_RCHIGH, 2);
 
-	COPY_ARRAY_TO_CONSTANT(MD_F2_K, this->F2_K, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_RC, this->F2_RC, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_R0, this->F2_R0, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_BLOW, this->F2_BLOW, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_BHIGH, this->F2_BHIGH, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_RLOW, this->F2_RLOW, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_RHIGH, this->F2_RHIGH, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_RCLOW, this->F2_RCLOW, 2);
-	COPY_ARRAY_TO_CONSTANT(MD_F2_RCHIGH, this->F2_RCHIGH, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_K, F2_K, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_RC, F2_RC, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_R0, F2_R0, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_BLOW, F2_BLOW, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_BHIGH, F2_BHIGH, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_RLOW, F2_RLOW, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_RHIGH, F2_RHIGH, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_RCLOW, F2_RCLOW, 2);
+	COPY_ARRAY_TO_CONSTANT(MD_F2_RCHIGH, F2_RCHIGH, 2);
 
-	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_A, this->F5_PHI_A, 4);
-	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_B, this->F5_PHI_B, 4);
-	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_XC, this->F5_PHI_XC, 4);
-	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_XS, this->F5_PHI_XS, 4);
+	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_A, F5_PHI_A, 4);
+	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_B, F5_PHI_B, 4);
+	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_XC, F5_PHI_XC, 4);
+	COPY_ARRAY_TO_CONSTANT(MD_F5_PHI_XS, F5_PHI_XS, 4);
 
 	CUDAModel cudamodel;
-	copy_Model_to_CUDAModel(*(this->model), cudamodel);
+	copy_Model_to_CUDAModel(*(model), cudamodel);
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(rnamodel, &cudamodel, sizeof(CUDAModel)));
 
-	if(this->_use_edge) CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_n_forces, &this->_n_forces, sizeof(int)));
+	if(_use_edge) CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_n_forces, &_n_forces, sizeof(int)));
 	if(_use_debye_huckel) {
 		// copied from DNA2Interaction::init() (CPU), the least bad way of doing things, adapted for RNA
-		// We wish to normalise with respect to T=300K, I=1M. 300K=0.1 s.u. so divide this->_T by 0.1
-		c_number lambda = _debye_huckel_lambdafactor * sqrt(this->_T / 0.1f) / sqrt(_salt_concentration);
+		// We wish to normalise with respect to T=300K, I=1M. 300K=0.1 s.u. so divide _T by 0.1
+		c_number lambda = _debye_huckel_lambdafactor * sqrt(_T / 0.1f) / sqrt(_salt_concentration);
 		// RHIGH gives the distance at which the smoothing begins
 		_debye_huckel_RHIGH = 3.0 * lambda;
 		_minus_kappa = -1.0 / lambda;
@@ -356,12 +358,12 @@ void CUDARNAInteraction::cuda_init(int N) {
 		_debye_huckel_B = -(exp(-x / l) * q * q * (x + l) * (x + l)) / (-4. * x * x * x * l * l * q);
 		_debye_huckel_RC = x * (q * x + 3. * q * l) / (q * (x + l));
 
-		c_number debyecut = 2. * sqrt(SQR(this->model->RNA_POS_BACK_a1) + SQR(this->model->RNA_POS_BACK_a2) + SQR(this->model->RNA_POS_BACK_a3)) + _debye_huckel_RC;
+		c_number debyecut = 2. * sqrt(SQR(model->RNA_POS_BACK_a1) + SQR(model->RNA_POS_BACK_a2) + SQR(model->RNA_POS_BACK_a3)) + _debye_huckel_RC;
 
 		// the cutoff radius for the potential should be the larger of rcut and debyecut
-		if(debyecut > this->_rcut) {
-			this->_rcut = debyecut;
-			this->_sqr_rcut = debyecut * debyecut;
+		if(debyecut > _rcut) {
+			_rcut = debyecut;
+			_sqr_rcut = debyecut * debyecut;
 		}
 		// End copy from cpu interaction
 		CUDA_SAFE_CALL(cudaMemcpyToSymbol(MD_dh_RC, &_debye_huckel_RC, sizeof(float)));
@@ -377,28 +379,40 @@ void CUDARNAInteraction::_on_T_update() {
 	cuda_init(_N);
 }
 
+void CUDARNAInteraction::_init_strand_ends(LR_bonds *d_bonds) {
+	CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<int>(&_d_is_strand_end, sizeof(int) * _N));
+	init_RNA_strand_ends<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>(_d_is_strand_end, d_bonds, _N);
+}
+
 void CUDARNAInteraction::compute_forces(CUDABaseList*lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box) {
+	if(_d_is_strand_end == nullptr) {
+		_init_strand_ends(d_bonds);
+	}
+
 	if(_use_edge) {
 		if(_n_forces == 1) { // we can directly use d_forces and d_torques so that no sum is required
 			rna_forces_edge_nonbonded
 				<<<(lists->N_edges - 1)/(_launch_cfg.threads_per_block) + 1, _launch_cfg.threads_per_block>>>
-				(d_poss, d_orientations, d_forces, d_torques, lists->d_edge_list, lists->N_edges, d_bonds, this->_average,this->_use_debye_huckel,this->_mismatch_repulsion, d_box);
+				(d_poss, d_orientations, d_forces, d_torques, lists->d_edge_list, lists->N_edges, _d_is_strand_end,
+				_average,_use_debye_huckel,_mismatch_repulsion, d_box);
 		}
 		else { // sum required, somewhat slower
 			rna_forces_edge_nonbonded
 				<<<(lists->N_edges - 1)/(_launch_cfg.threads_per_block) + 1, _launch_cfg.threads_per_block>>>
-				(d_poss, d_orientations, _d_edge_forces, _d_edge_torques, lists->d_edge_list, lists->N_edges, d_bonds, this->_average,this->_use_debye_huckel,this->_mismatch_repulsion, d_box);
+				(d_poss, d_orientations, _d_edge_forces, _d_edge_torques, lists->d_edge_list, lists->N_edges,
+				_d_is_strand_end, _average,_use_debye_huckel,_mismatch_repulsion, d_box);
 			_sum_edge_forces_torques(d_forces, d_torques);
 		}
 
 		rna_forces_edge_bonded
-			<<<this->_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
+			<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
 			(d_poss, d_orientations, d_forces, d_torques, d_bonds, _average, _use_mbf, _mbf_xmax, _mbf_finf);
 	}
 	else {
 		rna_forces
-			<<<this->_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
-			(d_poss, d_orientations, d_forces, d_torques, lists->d_matrix_neighs, lists->d_number_neighs, d_bonds, this->_average,this->_use_debye_huckel,this->_mismatch_repulsion, this->_use_mbf,this->_mbf_xmax, this->_mbf_finf, d_box);
+			<<<_launch_cfg.blocks, _launch_cfg.threads_per_block>>>
+			(d_poss, d_orientations, d_forces, d_torques, lists->d_matrix_neighs, lists->d_number_neighs, d_bonds,
+					_average,_use_debye_huckel,_mismatch_repulsion, _use_mbf,_mbf_xmax, _mbf_finf, d_box);
 		CUT_CHECK_ERROR("forces_second_step simple_lists error");
 	}
 }

--- a/src/CUDA/Interactions/CUDARNAInteraction.h
+++ b/src/CUDA/Interactions/CUDARNAInteraction.h
@@ -37,8 +37,8 @@ public:
 	CUDARNAInteraction();
 	virtual ~CUDARNAInteraction();
 
-	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void get_settings(input_file &inp) override;
+	void cuda_init(int N) override;
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/src/CUDA/Interactions/CUDARNAInteraction.h
+++ b/src/CUDA/Interactions/CUDARNAInteraction.h
@@ -33,6 +33,7 @@ public:
 	float _debye_huckel_B; // prefactor of the quadratic cut-off
 	float _minus_kappa;
 	// End copy from DNA2Interaction.h
+	int *_d_is_strand_end = nullptr;
 
 	CUDARNAInteraction();
 	virtual ~CUDARNAInteraction();
@@ -44,6 +45,7 @@ public:
 	}
 
 	void _on_T_update() override;
+	void _init_strand_ends(LR_bonds *d_bonds);
 
 	void compute_forces(CUDABaseList*lists, c_number4 *d_poss, GPU_quat *d_orientations, c_number4 *d_forces, c_number4 *d_torques, LR_bonds *d_bonds, CUDABox*d_box);
 	void _hb_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op_pairs1, int *op_pairs2, float *hb_energies, int n_threads, bool *region_is_nearhb, CUDA_kernel_cfg hb_kernel_cfg, CUDABox*d_box);

--- a/src/CUDA/Interactions/CUDATEPInteraction.h
+++ b/src/CUDA/Interactions/CUDATEPInteraction.h
@@ -24,8 +24,8 @@ public:
 	CUDATEPInteraction();
 	virtual ~CUDATEPInteraction();
 
-	void get_settings(input_file &inp);
-	void cuda_init(c_number box_side, int N);
+	void get_settings(input_file &inp) override;
+	void cuda_init(int N) override;
 	c_number get_cuda_rcut() {
 		return this->get_rcut();
 	}

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -304,14 +304,13 @@ __device__ void _bonded_part(c_number4 &n5pos, c_number4 &n5x, c_number4 &n5y, c
 
 	if(qIsN3) {
 		F += Ftmp;
-		_update_stress_tensor<true>(p_st, r, Ftmp);
 		T += Ttmp;
 	}
 	else {
 		F -= Ftmp;
-		_update_stress_tensor<true>(p_st, r, -Ftmp);
 		T -= Ttmp;
 	}
+	_update_stress_tensor<true>(p_st, r, Ftmp);
 
 	// STACKING
 	c_number4 rstack = r + n3pos_stack - n5pos_stack;
@@ -421,7 +420,6 @@ __device__ void _bonded_part(c_number4 &n5pos, c_number4 &n5x, c_number4 &n5y, c
 
 			T += Ttmp;
 			F += Ftmp;
-			_update_stress_tensor<true>(p_st, r, Ftmp);
 		}
 		else {
 			// THETA 6
@@ -429,8 +427,8 @@ __device__ void _bonded_part(c_number4 &n5pos, c_number4 &n5x, c_number4 &n5y, c
 
 			T -= Ttmp;
 			F -= Ftmp;
-			_update_stress_tensor<true>(p_st, r, -Ftmp);
 		}
+		_update_stress_tensor<true>(p_st, r, Ftmp);
 	}
 }
 

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -404,7 +404,7 @@ __device__ void _bonded_part(const c_number4 &r, const c_number4 &n5pos, const c
 	}
 }
 
-__device__ void _particle_particle_interaction(const c_number4 &r, const c_number4 &ppos, const c_number4 &a1, const c_number4 &a2, const c_number4 &a3,
+__device__ void _particle_particle_DNA_interaction(const c_number4 &r, const c_number4 &ppos, const c_number4 &a1, const c_number4 &a2, const c_number4 &a3,
 		const c_number4 &qpos, const c_number4 &b1,	const c_number4 &b2, const c_number4 &b3, c_number4 &F, c_number4 &T, bool grooving,
 		bool use_debye_huckel, bool use_oxDNA2_coaxial_stacking,
 		bool p_is_end, bool q_is_end) {
@@ -748,7 +748,7 @@ __global__ void dna_forces_edge_nonbonded(const c_number4 __restrict__ *poss, co
 	get_vectors_from_quat(orientations[b.to], b1, b2, b3);
 
 	c_number4 r = box->minimum_image(ppos, qpos);
-	_particle_particle_interaction(r, ppos, a1, a2, a3, qpos, b1, b2, b3, dF, dT, grooving, use_debye_huckel, use_oxDNA2_coaxial_stacking, p_is_end, q_is_end);
+	_particle_particle_DNA_interaction(r, ppos, a1, a2, a3, qpos, b1, b2, b3, dF, dT, grooving, use_debye_huckel, use_oxDNA2_coaxial_stacking, p_is_end, q_is_end);
 
 	int from_index = MD_N[0] * (IND % MD_n_forces[0]) + b.from;
 	int to_index = MD_N[0] * (IND % MD_n_forces[0]) + b.to;
@@ -887,7 +887,7 @@ __global__ void dna_forces(const c_number4 __restrict__ *poss, const GPU_quat __
 			bool q_is_end = (qbonds.n3 == P_INVALID || qbonds.n5 == P_INVALID);
 
 			c_number4 dF = make_c_number4(0, 0, 0, 0);
-			_particle_particle_interaction(r, ppos, a1, a2, a3, qpos, b1, b2, b3, dF, T, grooving, use_debye_huckel, use_oxDNA2_coaxial_stacking, p_is_end, q_is_end);
+			_particle_particle_DNA_interaction(r, ppos, a1, a2, a3, qpos, b1, b2, b3, dF, T, grooving, use_debye_huckel, use_oxDNA2_coaxial_stacking, p_is_end, q_is_end);
 			_update_stress_tensor<true>(p_st, r, dF);
 			F += dF;
 		}

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -860,7 +860,7 @@ __global__ void dna_forces_edge_bonded(c_number4 *poss, GPU_quat *orientations, 
 	c_number4 ppos = poss[IND];
 	LR_bonds bs = bonds[IND];
 
-	CUDAStressTensor p_st;
+	CUDAStressTensor p_st = st[IND];
 
 	// particle axes according to Allen's paper
 	c_number4 a1, a2, a3;

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -740,10 +740,10 @@ __global__ void dna_forces_edge_nonbonded(const c_number4 __restrict__ *poss, co
 	// particle axes according to Allen's paper
 	c_number4 a1, a2, a3;
 	get_vectors_from_quat(orientations[b.from], a1, a2, a3);
+
 	// get info for particle 2
 	c_number4 qpos = poss[b.to];
 	bool q_is_end = (use_debye_huckel) ? is_strand_end[b.to] : false;
-
 	c_number4 b1, b2, b3;
 	get_vectors_from_quat(orientations[b.to], b1, b2, b3);
 

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -86,22 +86,21 @@ __forceinline__ __device__ c_number _f1(c_number r, int type, int n3, int n5) {
 
 __forceinline__ __device__ c_number _f1D(c_number r, int type, int n3, int n5) {
 	c_number val = (c_number) 0.f;
-	int eps_index = 0;
 	if(r < MD_F1_RCHIGH[type]) {
-		eps_index = 25 * type + n3 * 5 + n5;
+		float eps = MD_F1_EPS[25 * type + n3 * 5 + n5];
 		if(r > MD_F1_RHIGH[type]) {
-			val = 2.f * MD_F1_BHIGH[type] * (r - MD_F1_RCHIGH[type]);
+			val = 2.f * eps * MD_F1_BHIGH[type] * (r - MD_F1_RCHIGH[type]);
 		}
 		else if(r > MD_F1_RLOW[type]) {
 			c_number tmp = expf(-(r - MD_F1_R0[type]) * MD_F1_A[type]);
-			val = 2.f * (1.f - tmp) * tmp * MD_F1_A[type];
+			val = 2.f * eps * (1.f - tmp) * tmp * MD_F1_A[type];
 		}
 		else if(r > MD_F1_RCLOW[type]) {
-			val = 2.f * MD_F1_BLOW[type] * (r - MD_F1_RCLOW[type]);
+			val = 2.f * eps * MD_F1_BLOW[type] * (r - MD_F1_RCLOW[type]);
 		}
 	}
 
-	return MD_F1_EPS[eps_index] * val;
+	return val;
 }
 
 __forceinline__ __device__ c_number _f2(c_number r, int type) {

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -204,12 +204,6 @@ __forceinline__ __device__ c_number _f5D(c_number f, int type) {
 	return val;
 }
 
-__device__ c_number4 stably_normalised(const c_number4 &v) {
-	c_number max = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)), fabsf(v.z));
-	c_number4 res = v / max;
-	return res / _module(res);
-}
-
 template<bool qIsN3>
 __device__ void _bonded_excluded_volume(const c_number4 &r, const c_number4 &n3pos_base, const c_number4 &n3pos_back, const c_number4 &n5pos_base,
 		const c_number4 &n5pos_back, c_number4 &F, c_number4 &T) {
@@ -1074,8 +1068,8 @@ __global__ void dist_op_precalc(c_number4 *poss, GPU_quat *orientations, int *op
 	op_dists[IND] = _module(rbase);
 }
 
-__global__ void init_strand_ends(int *is_strand_end, const LR_bonds __restrict__ *bonds) {
-	if(IND >= MD_N[0]) return;
+__global__ void init_DNA_strand_ends(int *is_strand_end, const LR_bonds __restrict__ *bonds, int N) {
+	if(IND >= N) return;
 
 	LR_bonds pbonds = bonds[IND];
 	is_strand_end[IND] = (pbonds.n3 == P_INVALID || pbonds.n5 == P_INVALID);

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -824,6 +824,7 @@ __global__ void dna_forces_edge_bonded(const c_number4 __restrict__ *poss, const
 		F += dF;
 	}
 
+	// we can do this because dna_forces_edge_nonbonded does not change the reference frame to the torque it calculates
 	T = _vectors_transpose_c_number4_product(a1, a2, a3, T);
 
 	forces[IND] = F;

--- a/src/CUDA/Interactions/CUDA_LJ.cuh
+++ b/src/CUDA/Interactions/CUDA_LJ.cuh
@@ -68,7 +68,6 @@ __global__ void lj_forces(c_number4 *poss, c_number4 *forces, int *matrix_neighs
 	c_number4 ppos = poss[IND];
 
 	int num_neighs = NUMBER_NEIGHBOURS(IND, number_neighs);
-
 	for(int j = 0; j < num_neighs; j++) {
 		int k_index = NEXT_NEIGHBOUR(IND, j, matrix_neighs);
 

--- a/src/CUDA/Interactions/CUDA_LJ.cuh
+++ b/src/CUDA/Interactions/CUDA_LJ.cuh
@@ -9,7 +9,7 @@ __constant__ int MD_LJ_n[3];
 
 #include "../cuda_utils/CUDA_lr_common.cuh"
 
-__device__ void _particle_particle_interaction(c_number4 &ppos, c_number4 &qpos, c_number4 &F, CUDABox*box) {
+__device__ void _particle_particle_interaction(c_number4 &ppos, c_number4 &qpos, c_number4 &F, CUDABox *box) {
 	int ptype = get_particle_type(ppos);
 	int qtype = get_particle_type(qpos);
 	int type = ptype + qtype;
@@ -34,25 +34,7 @@ __device__ void _particle_particle_interaction(c_number4 &ppos, c_number4 &qpos,
 	F.w += energy;
 }
 
-// forces + second step without lists
-__global__ void lj_forces(c_number4 *poss, c_number4 *forces, CUDABox*box) {
-	if(IND >= MD_N[0]) return;
-
-	c_number4 F = forces[IND];
-	c_number4 ppos = poss[IND];
-
-	for(int j = 0; j < MD_N[0]; j++) {
-		if(j != IND) {
-			c_number4 qpos = poss[j];
-
-			_particle_particle_interaction(ppos, qpos, F, box);
-		}
-	}
-
-	forces[IND] = F;
-}
-
-__global__ void lj_forces_edge(c_number4 *poss, c_number4 *forces, edge_bond *edge_list, int n_edges, CUDABox*box) {
+__global__ void lj_forces_edge(c_number4 *poss, c_number4 *forces, edge_bond *edge_list, int n_edges, CUDABox *box) {
 	if(IND >= n_edges) return;
 
 	c_number4 dF = make_c_number4(0.f, 0.f, 0.f, 0.f);
@@ -79,20 +61,21 @@ __global__ void lj_forces_edge(c_number4 *poss, c_number4 *forces, edge_bond *ed
 	if((dF.x * dF.x + dF.y * dF.y + dF.z * dF.z) > (c_number) 0.f) LR_atomicAddXYZ(forces + to_index, dF);
 }
 
-// forces + second step with verlet lists
-__global__ void lj_forces(c_number4 *poss, c_number4 *forces, int *matrix_neighs, int *c_number_neighs, CUDABox*box) {
+__global__ void lj_forces(c_number4 *poss, c_number4 *forces, int *matrix_neighs, int *number_neighs, CUDABox *box) {
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
 	c_number4 ppos = poss[IND];
 
-	int num_neighs = c_number_neighs[IND];
+	int num_neighs = NUMBER_NEIGHBOURS(IND, number_neighs);
 
 	for(int j = 0; j < num_neighs; j++) {
-		int k_index = matrix_neighs[j * MD_N[0] + IND];
+		int k_index = NEXT_NEIGHBOUR(IND, j, matrix_neighs);
 
-		c_number4 qpos = poss[k_index];
-		_particle_particle_interaction(ppos, qpos, F, box);
+		if(k_index != IND) {
+			c_number4 qpos = poss[k_index];
+			_particle_particle_interaction(ppos, qpos, F, box);
+		}
 	}
 
 	forces[IND] = F;

--- a/src/CUDA/Interactions/CUDA_RNA.cuh
+++ b/src/CUDA/Interactions/CUDA_RNA.cuh
@@ -1173,53 +1173,6 @@ void _particle_particle_interaction(c_number4 ppos, c_number4 a1, c_number4 a2, 
 	T.w = old_Tw + hb_energy;
 }
 
-// forces + second step without lists
-__global__ void rna_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *torques, LR_bonds *bonds, bool average, bool use_debye_huckel, bool mismatch_repulsion, bool use_mbf, c_number mbf_xmax, c_number mbf_finf, CUDABox *box) {
-	if(IND >= MD_N[0]) return;
-
-	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
-	LR_bonds bs = bonds[IND];
-	c_number4 ppos = poss[IND];
-	c_number4 a1, a2, a3;
-	get_vectors_from_quat(orientations[IND], a1, a2, a3); //Returns vectors a1,a2 and a3 as they would be in the GPU matrix. These are necessary even in pure quaternion dynamics
-
-	if(bs.n3 != P_INVALID) {
-		c_number4 qpos = poss[bs.n3];
-		c_number4 b1, b2, b3;
-		get_vectors_from_quat(orientations[bs.n3], b1, b2, b3);
-		_bonded_part<true>(ppos, a1, a2, a3, qpos, b1, b2, b3, F, T, average, use_mbf, mbf_xmax, mbf_finf);
-
-	}
-
-	if(bs.n5 != P_INVALID) {
-		c_number4 qpos = poss[bs.n5];
-
-		c_number4 b1, b2, b3;
-		get_vectors_from_quat(orientations[bs.n5], b1, b2, b3);
-		_bonded_part<false>(qpos, b1, b2, b3, ppos, a1, a2, a3, F, T, average, use_mbf, mbf_xmax, mbf_finf);
-
-	}
-
-	const int type = get_particle_type(ppos);
-	T.w = (c_number) 0;
-	for(int j = 0; j < MD_N[0]; j++) {
-		if(j != IND && bs.n3 != j && bs.n5 != j) {
-			const c_number4 qpos = poss[j];
-			c_number4 b1, b2, b3;
-			get_vectors_from_quat(orientations[j], b1, b2, b3);
-			LR_bonds qbonds = bonds[j];
-
-			_particle_particle_interaction(ppos, a1, a2, a3, qpos, b1, b2, b3, F, T, average, use_debye_huckel, mismatch_repulsion, bs, qbonds, box);
-		}
-	}
-
-	T = _vectors_transpose_c_number4_product(a1, a2, a3, T);
-
-	forces[IND] = F;
-	torques[IND] = T;
-}
-
 __global__ void rna_forces_edge_nonbonded(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *torques, edge_bond *edge_list, int n_edges, LR_bonds *bonds, bool average, bool use_debye_huckel, bool mismatch_repulsion, CUDABox *box) {
 	if(IND >= n_edges) return;
 
@@ -1309,48 +1262,48 @@ __global__ void rna_forces_edge_bonded(c_number4 *poss, GPU_quat *orientations, 
 	torques[IND] = _vectors_transpose_c_number4_product(a1, a2, a3, torques[IND]);
 }
 
-// forces + second step with verlet lists
-__global__ void rna_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *torques, int *matrix_neighs, int *c_number_neighs, LR_bonds *bonds, bool average, bool use_debye_huckel, bool mismatch_repulsion, bool use_mbf, c_number mbf_xmax, c_number mbf_finf, CUDABox *box) {
+__global__ void rna_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *forces, c_number4 *torques, int *matrix_neighs, int *number_neighs, LR_bonds *bonds, bool average, bool use_debye_huckel, bool mismatch_repulsion, bool use_mbf, c_number mbf_xmax, c_number mbf_finf, CUDABox *box) {
 	if(IND >= MD_N[0]) return;
 
 	//c_number4 F = make_c_number4(0, 0, 0, 0);
 	c_number4 F = forces[IND];
 	c_number4 T = make_c_number4(0, 0, 0, 0);
 	c_number4 ppos = poss[IND];
-	LR_bonds bs = bonds[IND];
+	LR_bonds pbonds = bonds[IND];
 	// particle axes according to Allen's paper
 	c_number4 a1, a2, a3;
 	get_vectors_from_quat(orientations[IND], a1, a2, a3);
 
-	if(bs.n3 != P_INVALID) {
-		c_number4 qpos = poss[bs.n3];
+	if(pbonds.n3 != P_INVALID) {
+		c_number4 qpos = poss[pbonds.n3];
 		c_number4 b1, b2, b3;
-		get_vectors_from_quat(orientations[bs.n3], b1, b2, b3);
+		get_vectors_from_quat(orientations[pbonds.n3], b1, b2, b3);
 
 		_bonded_part<true>(ppos, a1, a2, a3, qpos, b1, b2, b3, F, T, average, use_mbf, mbf_xmax, mbf_finf);
 
 	}
-	if(bs.n5 != P_INVALID) {
-		c_number4 qpos = poss[bs.n5];
+	if(pbonds.n5 != P_INVALID) {
+		c_number4 qpos = poss[pbonds.n5];
 		c_number4 b1, b2, b3;
-		get_vectors_from_quat(orientations[bs.n5], b1, b2, b3);
+		get_vectors_from_quat(orientations[pbonds.n5], b1, b2, b3);
 
 		_bonded_part<false>(qpos, b1, b2, b3, ppos, a1, a2, a3, F, T, average, use_mbf, mbf_xmax, mbf_finf);
 	}
 
 	const int type = get_particle_type(ppos);
-	const int num_neighs = c_number_neighs[IND];
+	int num_neighs = NUMBER_NEIGHBOURS(IND, number_neighs);
 
 	T.w = (c_number) 0;
 	for(int j = 0; j < num_neighs; j++) {
-		const int k_index = matrix_neighs[j * MD_N[0] + IND];
+		int k_index = NEXT_NEIGHBOUR(IND, j, matrix_neighs);
 
-		const c_number4 qpos = poss[k_index];
-		c_number4 b1, b2, b3;
-		get_vectors_from_quat(orientations[k_index], b1, b2, b3);
-		LR_bonds pbonds = bonds[IND];
-		LR_bonds qbonds = bonds[k_index];
-		_particle_particle_interaction(ppos, a1, a2, a3, qpos, b1, b2, b3, F, T, average, use_debye_huckel, mismatch_repulsion, pbonds, qbonds, box);
+		if(k_index != IND && pbonds.n3 != k_index && pbonds.n5 != k_index) {
+			const c_number4 qpos = poss[k_index];
+			c_number4 b1, b2, b3;
+			get_vectors_from_quat(orientations[k_index], b1, b2, b3);
+			LR_bonds qbonds = bonds[k_index];
+			_particle_particle_interaction(ppos, a1, a2, a3, qpos, b1, b2, b3, F, T, average, use_debye_huckel, mismatch_repulsion, pbonds, qbonds, box);
+		}
 	}
 
 	T = _vectors_transpose_c_number4_product(a1, a2, a3, T);

--- a/src/CUDA/Lists/CUDABaseList.h
+++ b/src/CUDA/Lists/CUDABaseList.h
@@ -9,6 +9,9 @@
 #ifndef CUDABASELIST_H_
 #define CUDABASELIST_H_
 
+#define NUMBER_NEIGHBOURS(idx, number_neighs) (number_neighs == nullptr) ? MD_N[0] : number_neighs[idx];
+#define NEXT_NEIGHBOUR(idx, neigh, matrix_neighs) (matrix_neighs == nullptr) ? neigh : matrix_neighs[neigh * MD_N[0] + idx];
+
 #include "../CUDAUtils.h"
 #include "../cuda_utils/CUDABox.h"
 
@@ -26,6 +29,11 @@ protected:
 	CUDABox *_h_cuda_box, *_d_cuda_box;
 
 public:
+	int *d_matrix_neighs = nullptr;
+	int *d_number_neighs = nullptr;
+	edge_bond *d_edge_list = nullptr;
+	int N_edges = 0;
+
 	CUDABaseList() :
 					_use_edge(false),
 					_N(-1),

--- a/src/CUDA/Lists/CUDANoList.cu
+++ b/src/CUDA/Lists/CUDANoList.cu
@@ -7,10 +7,20 @@
 
 #include "CUDANoList.h"
 
+#include "../../Utilities/oxDNAException.h"
+
 CUDANoList::CUDANoList() {
 
 }
 
 CUDANoList::~CUDANoList() {
 
+}
+
+void CUDANoList::get_settings(input_file &inp) {
+	bool use_edge = false;
+	getInputBool(&inp, "use_edge", &use_edge, 0);
+	if(use_edge) {
+		throw oxDNAException("'CUDA_list = no' and 'use_edge = true' are incompatible");
+	}
 }

--- a/src/CUDA/Lists/CUDANoList.h
+++ b/src/CUDA/Lists/CUDANoList.h
@@ -23,7 +23,7 @@ public:
 	void update(c_number4 *poss, c_number4 *list_poss, LR_bonds *bonds) {}
 	void clean() {}
 
-	void get_settings(input_file &inp) {}
+	void get_settings(input_file &inp) override;
 };
 
 #endif /* CUDANOLIST_H_ */

--- a/src/CUDA/Lists/CUDASimpleVerletList.h
+++ b/src/CUDA/Lists/CUDASimpleVerletList.h
@@ -48,11 +48,6 @@ protected:
 	virtual void _init_cells(c_number4 *poss=nullptr);
 
 public:
-	int *d_matrix_neighs = nullptr;
-	int *d_number_neighs = nullptr;
-	edge_bond *d_edge_list = nullptr;
-	int N_edges;
-
 	CUDASimpleVerletList();
 	virtual ~CUDASimpleVerletList();
 

--- a/src/CUDA/Lists/CUDA_simple_verlet.cuh
+++ b/src/CUDA/Lists/CUDA_simple_verlet.cuh
@@ -105,12 +105,6 @@ __global__ void compress_matrix_neighs(int *matrix, int *nneighs, int *offsets, 
 			edge_bond b;
 			b.from = IND;
 			b.to = matrix[i * verlet_N[0] + IND];
-			b.n_from = i;
-			b.n_to = -1;
-			// we know n_from out of the box, now we have to look for "from" in "to"'s neighbour list
-			// in order to find n_to
-			for(int j = 0; j < nneighs[b.to] && b.n_to == -1; j++)
-				if(matrix[j * verlet_N[0] + b.to] == IND) b.n_to = j;
 			edge_list[offsets[IND] + ctr] = b;
 			ctr++;
 		}

--- a/src/CUDA/Lists/CUDA_simple_verlet.cuh
+++ b/src/CUDA/Lists/CUDA_simple_verlet.cuh
@@ -11,8 +11,6 @@ __constant__ int verlet_N[1];
 __constant__ int verlet_N_cells_side[3];
 __constant__ int verlet_max_N_per_cell[1];
 
-//texture<int, 1, cudaReadModeElementType> counters_cells_tex;
-
 __forceinline__ __device__ int neigh_cell(int3 index, int3 offset) {
 	// neighbour cell of this cell
 	index.x = (index.x + verlet_N_cells_side[0] + offset.x) % verlet_N_cells_side[0];

--- a/src/CUDA/cuda_defs.h
+++ b/src/CUDA/cuda_defs.h
@@ -91,11 +91,9 @@ __align__(8) {
 /**
  * @brief Used when use_edge = true. It stores information associated to a single bond.
  */
-typedef struct __align__(16) edge_bond {
+typedef struct __align__(8) edge_bond {
 	int from;
 	int to;
-	int n_from;
-	int n_to;
 } edge_bond;
 
 /**

--- a/src/CUDA/cuda_defs.h
+++ b/src/CUDA/cuda_defs.h
@@ -89,13 +89,70 @@ __align__(8) {
 } LR_bonds;
 
 /**
-* @brief Used when use_edge = true. It stores information associated to a single bond.
-*/
+ * @brief Used when use_edge = true. It stores information associated to a single bond.
+ */
 typedef struct __align__(16) edge_bond {
 	int from;
 	int to;
 	int n_from;
 	int n_to;
 } edge_bond;
+
+/**
+ * @brief Used to store the stress tensor on GPUs
+ */
+__device__ __host__ struct __align__(16) CUDAStressTensor {
+	c_number e[6];
+
+	__device__ __host__ CUDAStressTensor() : e{0} {
+
+	}
+
+	__device__ __host__ CUDAStressTensor(c_number e0, c_number e1, c_number e2, c_number e3, c_number e4, c_number e5) :
+		e{e0, e1, e2, e3, e4, e5} {
+
+	}
+
+	__device__ __host__ inline CUDAStressTensor operator+(const CUDAStressTensor &other) const {
+		return CUDAStressTensor(
+				e[0] + other.e[0],
+				e[1] + other.e[1],
+				e[2] + other.e[2],
+				e[3] + other.e[3],
+				e[4] + other.e[4],
+				e[5] + other.e[5]);
+	}
+
+	__device__ __host__ inline void operator+=(const CUDAStressTensor &other) {
+		e[0] += other.e[0];
+		e[1] += other.e[1];
+		e[2] += other.e[2];
+		e[3] += other.e[3];
+		e[4] += other.e[4];
+		e[5] += other.e[5];
+	}
+
+	__device__ __host__ inline void operator*=(const c_number other) {
+		e[0] *= other;
+		e[1] *= other;
+		e[2] *= other;
+		e[3] *= other;
+		e[4] *= other;
+		e[5] *= other;
+	}
+
+	__device__ __host__ inline void operator/=(const c_number other) {
+		e[0] /= other;
+		e[1] /= other;
+		e[2] /= other;
+		e[3] /= other;
+		e[4] /= other;
+		e[5] /= other;
+	}
+
+	__host__ StressTensor as_StressTensor() {
+		return StressTensor({e[0], e[1], e[2], e[3], e[4], e[5]});
+	}
+};
 
 #endif /* SRC_CUDA_CUDA_DEFS_H_ */

--- a/src/CUDA/cuda_defs.h
+++ b/src/CUDA/cuda_defs.h
@@ -99,7 +99,7 @@ typedef struct __align__(8) edge_bond {
 /**
  * @brief Used to store the stress tensor on GPUs
  */
-__device__ __host__ struct __align__(16) CUDAStressTensor {
+typedef struct __align__(16) CUDAStressTensor {
 	c_number e[6];
 
 	__device__ __host__ CUDAStressTensor() : e{0} {
@@ -151,6 +151,6 @@ __device__ __host__ struct __align__(16) CUDAStressTensor {
 	__host__ StressTensor as_StressTensor() {
 		return StressTensor({e[0], e[1], e[2], e[3], e[4], e[5]});
 	}
-};
+} CUDAStressTensor;
 
 #endif /* SRC_CUDA_CUDA_DEFS_H_ */

--- a/src/CUDA/cuda_defs.h
+++ b/src/CUDA/cuda_defs.h
@@ -9,7 +9,15 @@
 #define SRC_CUDA_CUDA_DEFS_H_
 
 /// CUDA_SAFE_CALL replacement for backwards compatibility (CUDA < 5.0)
-#define CUDA_SAFE_CALL(x) checkCudaErrors(x);
+#define CUDA_SAFE_CALL(call)                                  \
+  do {                                                        \
+    cudaError_t err = call;                                   \
+    if (err != cudaSuccess) {                                 \
+      printf("CUDA error at %s %d: %s\n", __FILE__, __LINE__, \
+             cudaGetErrorString(err));                        \
+      exit(EXIT_FAILURE);                                     \
+    }                                                         \
+  } while (0)
 /// CUT_CHECK_ERROR replacement for backwards compatibility (CUDA < 5.0)
 #define CUT_CHECK_ERROR(x) getLastCudaError(x);
 
@@ -33,7 +41,7 @@
 #define COPY_ARRAY_TO_CONSTANT(dest, src, size) {\
 		float *val = new float[(size)];\
 		for(int i = 0; i < (size); i++) val[i] = (float) ((src)[i]);\
-		CUDA_SAFE_CALL(cudaMemcpyToSymbol((dest), val, (size)*sizeof(float)))\
+		CUDA_SAFE_CALL(cudaMemcpyToSymbol((dest), val, (size)*sizeof(float)));\
 		delete[] val; }
 
 #define COPY_NUMBER_TO_FLOAT(dest, src) {\

--- a/src/CUDA/cuda_utils/CUDABox.h
+++ b/src/CUDA/cuda_utils/CUDABox.h
@@ -38,7 +38,7 @@ public:
 
 	}
 
-	__forceinline__ __device__ c_number4 minimum_image(c_number4 &r_i, c_number4 &r_j) {
+	__forceinline__ __device__ c_number4 minimum_image(const c_number4 &r_i, const c_number4 &r_j) const {
 		c_number4 res;
 		res.x = r_j.x - r_i.x;
 		res.y = r_j.y - r_i.y;
@@ -51,12 +51,12 @@ public:
 		return res;
 	}
 
-	__forceinline__ __device__ c_number sqr_minimum_image(c_number4 &r_i, c_number4 &r_j) {
+	__forceinline__ __device__ c_number sqr_minimum_image(const c_number4 &r_i, const c_number4 &r_j) const {
 		c_number4 mi = minimum_image(r_i, r_j);
 		return SQR(mi.x) + SQR(mi.y) + SQR(mi.z);
 	}
 
-	__forceinline__ __device__ int compute_cell_index(int N_cells_side[3], float4 &r) {
+	__forceinline__ __device__ int compute_cell_index(const int N_cells_side[3], const float4 &r) const {
 		int cx = ((r.x / _Lx - floorf(r.x / _Lx)) * (1.f - FLT_EPSILON)) * N_cells_side[0];
 		int cy = ((r.y / _Ly - floorf(r.y / _Ly)) * (1.f - FLT_EPSILON)) * N_cells_side[1];
 		int cz = ((r.z / _Lz - floorf(r.z / _Lz)) * (1.f - FLT_EPSILON)) * N_cells_side[2];
@@ -64,7 +64,7 @@ public:
 		return (cz * N_cells_side[1] + cy) * N_cells_side[0] + cx;
 	}
 
-	__forceinline__ __device__ int3 compute_cell_spl_idx(int N_cells_side[3], float4 &r) {
+	__forceinline__ __device__ int3 compute_cell_spl_idx(const int N_cells_side[3], const float4 &r) const {
 		int cx = (r.x / _Lx - floorf(r.x / _Lx)) * (1.f - FLT_EPSILON) * N_cells_side[0];
 		int cy = (r.y / _Ly - floorf(r.y / _Ly)) * (1.f - FLT_EPSILON) * N_cells_side[1];
 		int cz = (r.z / _Lz - floorf(r.z / _Lz)) * (1.f - FLT_EPSILON) * N_cells_side[2];
@@ -72,7 +72,7 @@ public:
 		return make_int3(cx, cy, cz);
 	}
 
-	__forceinline__ __device__ int compute_cell_index(int N_cells_side[3], LR_double4 &r) {
+	__forceinline__ __device__ int compute_cell_index(const int N_cells_side[3], const LR_double4 &r) const {
 		int cx = (r.x / _Lx - floor(r.x / _Lx)) * (1. - DBL_EPSILON) * N_cells_side[0];
 		int cy = (r.y / _Ly - floor(r.y / _Ly)) * (1. - DBL_EPSILON) * N_cells_side[1];
 		int cz = (r.z / _Lz - floor(r.z / _Lz)) * (1. - DBL_EPSILON) * N_cells_side[2];
@@ -80,7 +80,7 @@ public:
 		return (cz * N_cells_side[1] + cy) * N_cells_side[0] + cx;
 	}
 
-	__forceinline__ __device__ int3 compute_cell_spl_idx(int N_cells_side[3], LR_double4 &r) {
+	__forceinline__ __device__ int3 compute_cell_spl_idx(const int N_cells_side[3], const LR_double4 &r) const {
 		int cx = (r.x / _Lx - floor(r.x / _Lx)) * (1. - DBL_EPSILON) * N_cells_side[0];
 		int cy = (r.y / _Ly - floor(r.y / _Ly)) * (1. - DBL_EPSILON) * N_cells_side[1];
 		int cz = (r.z / _Lz - floor(r.z / _Lz)) * (1. - DBL_EPSILON) * N_cells_side[2];

--- a/src/CUDA/cuda_utils/CUDA_lr_common.cuh
+++ b/src/CUDA/cuda_utils/CUDA_lr_common.cuh
@@ -177,11 +177,11 @@ __forceinline__ __host__ __device__ c_number4 make_c_number4(const c_number x, c
 	return ret;
 }
 
-__forceinline__ __device__ c_number _module(const c_number4 v) {
+__forceinline__ __device__ c_number _module(const c_number4 &v) {
 	return sqrtf(SQR(v.x) + SQR(v.y) + SQR(v.z));
 }
 
-__forceinline__ __device__ c_number _module(const float3 v) {
+__forceinline__ __device__ c_number _module(const float3 &v) {
 	return sqrtf(SQR(v.x) + SQR(v.y) + SQR(v.z));
 }
 
@@ -364,6 +364,12 @@ __forceinline__ __device__ void operator-=(float4 &a, float4 b) {
 	a.y -= b.y;
 	a.z -= b.z;
 	a.w += b.w;
+}
+
+__forceinline__ __device__ c_number4 stably_normalised(const c_number4 &v) {
+	c_number max = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)), fabsf(v.z));
+	c_number4 res = v / max;
+	return res / _module(res);
 }
 
 #endif /* CUDA_LR_COMMON */

--- a/src/CUDA/cuda_utils/CUDA_lr_common.cuh
+++ b/src/CUDA/cuda_utils/CUDA_lr_common.cuh
@@ -25,7 +25,7 @@
 // in the case of pair-wise forces, which are counted twice, one should set half=true
 // while three-body forces are counted only once, so half=false should be used.
 template<bool half>
-__device__ void _update_stress_tensor(CUDAStressTensor &st, c_number4 &r, c_number4 &force) {
+__device__ void _update_stress_tensor(CUDAStressTensor &st, const c_number4 &r, const c_number4 &force) {
 	c_number factor = (half) ? 0.5f : 1.0f;
 
 	st.e[0] -= r.x * force.x * factor;
@@ -115,6 +115,15 @@ __forceinline__ __device__ void LR_atomicAddXYZ(c_number4 *dst, c_number4 delta)
 	atomicAdd(&(dst->x), delta.x);
 	atomicAdd(&(dst->y), delta.y);
 	atomicAdd(&(dst->z), delta.z);
+}
+
+__forceinline__ __device__ void LR_atomicAddST(CUDAStressTensor *dst, CUDAStressTensor delta) {
+	atomicAdd(&(dst->e[0]), delta.e[0]);
+	atomicAdd(&(dst->e[1]), delta.e[1]);
+	atomicAdd(&(dst->e[2]), delta.e[2]);
+	atomicAdd(&(dst->e[3]), delta.e[3]);
+	atomicAdd(&(dst->e[4]), delta.e[4]);
+	atomicAdd(&(dst->e[5]), delta.e[5]);
 }
 
 /**

--- a/src/CUDA/cuda_utils/CUDA_lr_common.cuh
+++ b/src/CUDA/cuda_utils/CUDA_lr_common.cuh
@@ -22,6 +22,20 @@
 #define IND 0
 #endif
 
+// in the case of pair-wise forces, which are counted twice, one should set half=true
+// while three-body forces are counted only once, so half=false should be used.
+template<bool half>
+__device__ void _update_stress_tensor(CUDAStressTensor &st, c_number4 &r, c_number4 &force) {
+	c_number factor = (half) ? 0.5f : 1.0f;
+
+	st.e[0] -= r.x * force.x * factor;
+	st.e[1] -= r.y * force.y * factor;
+	st.e[2] -= r.z * force.z * factor;
+	st.e[3] -= r.x * force.y * factor;
+	st.e[4] -= r.x * force.z * factor;
+	st.e[5] -= r.y * force.z * factor;
+}
+
 //This is the most commonly called quaternion to matrix conversion. 
 __forceinline__ __device__ void get_vectors_from_quat(GPU_quat &q, c_number4 &a1, c_number4 &a2, c_number4 &a3) {
 	c_number sqx = q.x * q.x;

--- a/src/CUDA/cuda_utils/CUDA_lr_common.cuh
+++ b/src/CUDA/cuda_utils/CUDA_lr_common.cuh
@@ -37,7 +37,7 @@ __device__ void _update_stress_tensor(CUDAStressTensor &st, const c_number4 &r, 
 }
 
 //This is the most commonly called quaternion to matrix conversion. 
-__forceinline__ __device__ void get_vectors_from_quat(GPU_quat &q, c_number4 &a1, c_number4 &a2, c_number4 &a3) {
+__forceinline__ __device__ void get_vectors_from_quat(const GPU_quat &q, c_number4 &a1, c_number4 &a2, c_number4 &a3) {
 	c_number sqx = q.x * q.x;
 	c_number sqy = q.y * q.y;
 	c_number sqz = q.z * q.z;
@@ -61,7 +61,7 @@ __forceinline__ __device__ void get_vectors_from_quat(GPU_quat &q, c_number4 &a1
 }
 
 template<typename t_quat>
-__forceinline__ __device__ t_quat quat_multiply(t_quat &a, t_quat &b) {
+__forceinline__ __device__ t_quat quat_multiply(const t_quat &a, const t_quat &b) {
 	t_quat p;
 	p.w = a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z;
 	p.x = a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y;
@@ -104,20 +104,20 @@ __forceinline__ __device__ double atomicAdd(double* address, double val) {
 }
 #endif
 
-__forceinline__ __device__ void LR_atomicAdd(c_number4 *dst, c_number4 delta) {
+__forceinline__ __device__ void LR_atomicAdd(c_number4 *dst, const c_number4 &delta) {
 	atomicAdd(&(dst->x), delta.x);
 	atomicAdd(&(dst->y), delta.y);
 	atomicAdd(&(dst->z), delta.z);
 	atomicAdd(&(dst->w), delta.w);
 }
 
-__forceinline__ __device__ void LR_atomicAddXYZ(c_number4 *dst, c_number4 delta) {
+__forceinline__ __device__ void LR_atomicAddXYZ(c_number4 *dst, const c_number4 &delta) {
 	atomicAdd(&(dst->x), delta.x);
 	atomicAdd(&(dst->y), delta.y);
 	atomicAdd(&(dst->z), delta.z);
 }
 
-__forceinline__ __device__ void LR_atomicAddST(CUDAStressTensor *dst, CUDAStressTensor delta) {
+__forceinline__ __device__ void LR_atomicAddST(CUDAStressTensor *dst, const CUDAStressTensor &delta) {
 	atomicAdd(&(dst->e[0]), delta.e[0]);
 	atomicAdd(&(dst->e[1]), delta.e[1]);
 	atomicAdd(&(dst->e[2]), delta.e[2]);

--- a/src/CUDA/cuda_utils/CUDA_lr_common.cuh
+++ b/src/CUDA/cuda_utils/CUDA_lr_common.cuh
@@ -143,9 +143,7 @@ __forceinline__ __device__ c_number quad_distance(const c_number4 &r_i, const c_
 
 __forceinline__ __device__ int get_particle_type(const c_number4 &r_i) {
 	int my_btype = __float_as_int(r_i.w) >> 22;
-	if(my_btype >= 0 && my_btype <= 3) return my_btype;
-	if(my_btype > 0) return my_btype % 4;
-	else return 3 - ((3 - (my_btype)) % 4);
+	return (my_btype > 0) ? (my_btype & 3) : 3 - ((3 - (my_btype)) & 3); // a & 3 is equivalent to a % 4, but much faster
 }
 
 __forceinline__ __device__ int get_particle_index(const c_number4 &r_i) {

--- a/src/CUDA/cuda_utils/helper_cuda.h
+++ b/src/CUDA/cuda_utils/helper_cuda.h
@@ -47,7 +47,7 @@
 
 // CUDA Runtime error messages
 #ifdef __DRIVER_TYPES_H__
-static const char *_cudaGetErrorEnum(cudaError_t error)
+inline static const char *_cudaGetErrorEnum(cudaError_t error)
 {
     switch (error)
     {
@@ -250,7 +250,7 @@ static const char *_cudaGetErrorEnum(cudaError_t error)
 
 #ifdef __cuda_cuda_h__
 // CUDA Driver API errors
-static const char *_cudaGetErrorEnum(CUresult error)
+inline static const char *_cudaGetErrorEnum(CUresult error)
 {
     switch (error)
     {

--- a/src/Interactions/BaseInteraction.cpp
+++ b/src/Interactions/BaseInteraction.cpp
@@ -118,6 +118,14 @@ void BaseInteraction::_update_stress_tensor(LR_vector r_p, LR_vector group_force
 
 void BaseInteraction::reset_stress_tensor() {
 	std::fill(_stress_tensor.begin(), _stress_tensor.end(), 0.);
+	for(auto p : CONFIG_INFO->particles()) {
+		_stress_tensor[0] += SQR(p->vel.x);
+		_stress_tensor[1] += SQR(p->vel.y);
+		_stress_tensor[2] += SQR(p->vel.z);
+		_stress_tensor[3] += p->vel.x * p->vel.y;
+		_stress_tensor[4] += p->vel.x * p->vel.z;
+		_stress_tensor[5] += p->vel.y * p->vel.z;
+	}
 }
 
 number BaseInteraction::get_system_energy(std::vector<BaseParticle *> &particles, BaseList *lists) {

--- a/src/Interactions/BaseInteraction.h
+++ b/src/Interactions/BaseInteraction.h
@@ -113,13 +113,22 @@ public:
 	virtual void check_input_sanity(std::vector<BaseParticle *> &particles) = 0;
 
 	/**
-	 * @brief Signals the interaction that an energy (or force) computation is about to begin.
+	 * @brief Signals the interaction that an energy computation is about to begin.
 	 *
-	 * By default this method resets the stress tensor data structures and nothing else, but interactions inheriting from this interface may
+	 * By default this method does nothing, but interactions inheriting from this interface may
 	 * need to initialise or reset other data structures before computing the energy or the force acting on all particles.
 	 *
 	 */
 	virtual void begin_energy_computation();
+
+	/**
+	 * @brief Signals the interaction that an energy and force computation is about to begin.
+	 *
+	 * By default this method resets the stress tensor data structures, calls begin_energy_computationa() and nothing else, but interactions inheriting from this interface may
+	 * need to initialise or reset other data structures before computing the energy or the force acting on all particles.
+	 *
+	 */
+	virtual void begin_energy_and_force_computation();
 
 	/**
 	 * @brief Returns true if the interaction computes the stress tensor internally, false otherwise.

--- a/src/Interactions/BaseInteraction.h
+++ b/src/Interactions/BaseInteraction.h
@@ -20,12 +20,9 @@
 #include <fstream>
 #include <set>
 #include <vector>
-#include <array>
 #include <functional>
 
 #define ADD_INTERACTION_TO_MAP(index, member) {_interaction_map[index] = [this](BaseParticle *p, BaseParticle *q, bool compute_r, bool compute_forces) { return member(p, q, compute_r, compute_forces); };}
-
-using StressTensor = std::array<number, 6>;
 
 /**
  * @brief Base class for managing particle-particle interactions. It is an abstract class.
@@ -137,8 +134,12 @@ public:
 
 	void reset_stress_tensor();
 
-	StressTensor stress_tensor() const {
-		return _stress_tensor;
+	void compute_standard_stress_tensor();
+
+	StressTensor stress_tensor() const;
+
+	void set_stress_tensor(StressTensor st) {
+		_stress_tensor = st;
 	}
 
 	/**

--- a/src/Interactions/DNA2Interaction.cpp
+++ b/src/Interactions/DNA2Interaction.cpp
@@ -197,6 +197,8 @@ number DNA2Interaction::_debye_huckel(BaseParticle *p, BaseParticle *q, bool com
 			p->force -= force;
 			q->force += force;
 
+			_update_stress_tensor(_computed_r, force);
+
 			p->torque += p->orientationT * torquep;
 			q->torque += q->orientationT * torqueq;
 		}
@@ -284,6 +286,8 @@ number DNA2Interaction::_coaxial_stacking(BaseParticle *p, BaseParticle *q, bool
 			// final update of forces and torques for CXST
 			p->force -= force;
 			q->force += force;
+
+			_update_stress_tensor(_computed_r, force);
 
 			torquep -= p->int_centers[DNANucleotide::STACK].cross(force);
 			torqueq += q->int_centers[DNANucleotide::STACK].cross(force);

--- a/src/Interactions/DNAInteraction.cpp
+++ b/src/Interactions/DNAInteraction.cpp
@@ -440,6 +440,8 @@ number DNAInteraction::_backbone(BaseParticle *p, BaseParticle *q, bool compute_
 		p->force -= force;
 		q->force += force;
 
+		_update_stress_tensor(_computed_r, force);
+
 		p->torque -= p->orientationT * p->int_centers[DNANucleotide::BACK].cross(force);
 		q->torque += q->orientationT * q->int_centers[DNANucleotide::BACK].cross(force);
 	}
@@ -470,6 +472,8 @@ number DNAInteraction::_bonded_excluded_volume(BaseParticle *p, BaseParticle *q,
 
 		p->force -= force;
 		q->force += force;
+
+		_update_stress_tensor(_computed_r, force);
 	}
 
 	// P-BASE vs. Q-BACK
@@ -482,6 +486,8 @@ number DNAInteraction::_bonded_excluded_volume(BaseParticle *p, BaseParticle *q,
 
 		p->force -= force;
 		q->force += force;
+
+		_update_stress_tensor(_computed_r, force);
 	}
 
 	// P-BACK vs. Q-BASE
@@ -494,6 +500,8 @@ number DNAInteraction::_bonded_excluded_volume(BaseParticle *p, BaseParticle *q,
 
 		p->force -= force;
 		q->force += force;
+
+		_update_stress_tensor(_computed_r, force);
 
 		// we need torques in the reference system of the particle
 		p->torque += p->orientationT * torquep;
@@ -626,6 +634,8 @@ number DNAInteraction::_stacking(BaseParticle *p, BaseParticle *q, bool compute_
 		p->force -= force;
 		q->force += force;
 
+		_update_stress_tensor(_computed_r, force);
+
 		torquep -= p->int_centers[DNANucleotide::STACK].cross(force);
 		torqueq += q->int_centers[DNANucleotide::STACK].cross(force);
 
@@ -697,6 +707,8 @@ number DNAInteraction::_nonbonded_excluded_volume(BaseParticle *p, BaseParticle 
 
 		p->force -= force;
 		q->force += force;
+
+		_update_stress_tensor(_computed_r, force);
 	}
 
 	// P-BACK vs. Q-BASE
@@ -709,6 +721,8 @@ number DNAInteraction::_nonbonded_excluded_volume(BaseParticle *p, BaseParticle 
 
 		p->force -= force;
 		q->force += force;
+
+		_update_stress_tensor(_computed_r, force);
 	}
 
 	// P-BASE vs. Q-BACK
@@ -721,6 +735,8 @@ number DNAInteraction::_nonbonded_excluded_volume(BaseParticle *p, BaseParticle 
 
 		p->force -= force;
 		q->force += force;
+
+		_update_stress_tensor(_computed_r, force);
 	}
 
 	// BACK-BACK
@@ -733,6 +749,8 @@ number DNAInteraction::_nonbonded_excluded_volume(BaseParticle *p, BaseParticle 
 
 		p->force -= force;
 		q->force += force;
+
+		_update_stress_tensor(_computed_r, force);
 
 		// we need torques in the reference system of the particle
 		p->torque += p->orientationT * torquep;
@@ -853,6 +871,8 @@ number DNAInteraction::_hydrogen_bonding(BaseParticle *p, BaseParticle *q, bool 
 			p->force -= force;
 			q->force += force;
 
+			_update_stress_tensor(_computed_r, force);
+
 			torquep -= p->int_centers[DNANucleotide::BASE].cross(force);
 			torqueq += q->int_centers[DNANucleotide::BASE].cross(force);
 
@@ -969,6 +989,8 @@ number DNAInteraction::_cross_stacking(BaseParticle *p, BaseParticle *q, bool co
 			// final update of forces and torques for CRST
 			p->force -= force;
 			q->force += force;
+
+			_update_stress_tensor(_computed_r, force);
 
 			torquep -= p->int_centers[DNANucleotide::BASE].cross(force);
 			torqueq += q->int_centers[DNANucleotide::BASE].cross(force);
@@ -1118,6 +1140,8 @@ number DNAInteraction::_coaxial_stacking(BaseParticle *p, BaseParticle *q, bool 
 			// final update of forces and torques for CXST
 			p->force -= force;
 			q->force += force;
+
+			_update_stress_tensor(_computed_r, force);
 
 			torquep -= p->int_centers[DNANucleotide::STACK].cross(force);
 			torqueq += q->int_centers[DNANucleotide::STACK].cross(force);

--- a/src/Interactions/DNAInteraction.h
+++ b/src/Interactions/DNAInteraction.h
@@ -109,6 +109,10 @@ public:
 
 	virtual void allocate_particles(std::vector<BaseParticle *> &particles);
 
+	bool has_custom_stress_tensor() const override {
+		return true;
+	}
+
 	virtual number pair_interaction(BaseParticle *p, BaseParticle *q, bool compute_r = true, bool update_forces=false);
 	virtual number pair_interaction_bonded(BaseParticle *p, BaseParticle *q, bool compute_r = true, bool update_forces=false);
 	virtual number pair_interaction_nonbonded(BaseParticle *p, BaseParticle *q, bool compute_r = true, bool update_forces=false);

--- a/src/Interactions/DNAInteraction_nomesh.h
+++ b/src/Interactions/DNAInteraction_nomesh.h
@@ -26,8 +26,8 @@ protected:
 	 */
 	//virtual number _custom_f4 (number cost, int i) { return this->_query_mesh (cost, this->_mesh_f4[i]); }
 	virtual number _custom_f4 (number cost, int i) {
-		if (i != CXST_F4_THETA1) return this->_fakef4 (cost, (void *)&i);
-		else return this->_fakef4_cxst_t1 (cost, (void *)&i);
+		if (i != CXST_F4_THETA1) return this->_fakef4(cost, (void *)&i);
+		else return this->_fakef4_cxst_t1(cost, (void *)&i);
 	}
 
 	/**
@@ -38,8 +38,8 @@ protected:
 	 */
 	//virtual number _custom_f4D (number cost, int i) { return this->_query_meshD (cost, this->_mesh_f4[i]); }
 	virtual number _custom_f4D (number cost, int i) {
-		if (i != CXST_F4_THETA1) return this->_fakef4D (cost, (void *)&i);
-		else return this->_fakef4D_cxst_t1 (cost, (void *)&i);
+		if (i != CXST_F4_THETA1) return this->_fakef4D(cost, (void *)&i);
+		else return this->_fakef4D_cxst_t1(cost, (void *)&i);
 	}
 
 public:

--- a/src/Interactions/DNAInteraction_relax.cpp
+++ b/src/Interactions/DNAInteraction_relax.cpp
@@ -49,6 +49,8 @@ number DNAInteraction_relax::_backbone(BaseParticle *p, BaseParticle *q, bool co
 		p->force -= force;
 		q->force += force;
 
+		_update_stress_tensor(_computed_r, force);
+
 		// we need torques in the reference system of the particle
 		p->torque -= p->orientationT * p->int_centers[DNANucleotide::BACK].cross(force);
 		q->torque += q->orientationT * q->int_centers[DNANucleotide::BACK].cross(force);

--- a/src/Interactions/RNAInteraction2.cpp
+++ b/src/Interactions/RNAInteraction2.cpp
@@ -55,11 +55,6 @@ void RNA2Interaction::get_settings(input_file &inp) {
 		_debye_huckel_lambdafactor = 0.3667258;
 	}
 
-	if(getInputBoolAsInt(&inp, "lambda_T_dependent", &lambda_T_dependent, 0) == KEY_FOUND && lambda_T_dependent) {
-		OX_LOG(Logger::LOG_INFO,"Running Debye-Huckel with temperature dependent lambda at T = %f",_T);
-		_debye_huckel_lambdafactor *= sqrt(_T / 0.1f);
-	}
-
 	// read the prefactor to the potential, or set it to the default value
 	if(getInputFloat(&inp, "dh_strength", &prefactor, 0) == KEY_FOUND) {
 		_debye_huckel_prefactor = (float) prefactor;
@@ -118,10 +113,8 @@ void RNA2Interaction::init() {
 	RNAInteraction::init();
 
 	//compute the DH length lambda
-	number lambda = _debye_huckel_lambdafactor / sqrt(_salt_concentration);
+	number lambda = _debye_huckel_lambdafactor * sqrt(_T / 0.1f) / sqrt(_salt_concentration);
 
-	//_debye_huckel_RHIGH =  _debye_huckel_cutoff_factor * lambda - 0.1; //2.0 * lambda - 0.1;
-	//_debye_huckel_Vrc  = (_debye_huckel_prefactor / (_debye_huckel_cutoff_factor * lambda))  * exp(- _debye_huckel_cutoff_factor ) ;
 	_debye_huckel_Vrc = 0;
 	_minus_kappa = -1.0 / lambda;
 
@@ -135,7 +128,6 @@ void RNA2Interaction::init() {
 	_debye_huckel_RC = x * (q * x + 3. * q * l - 2.0 * exp(x / l) * V * x * l) / (q * (x + l));
 
 	number debyecut = 2. * sqrt(SQR(model->RNA_POS_BACK_a1) + SQR(model->RNA_POS_BACK_a2) + SQR(model->RNA_POS_BACK_a3)) + _debye_huckel_RC;
-	//number debyecut = 2. * sqrt(SQR(POS_BACK) ) + _debye_huckel_RC;
 	if(debyecut > _rcut) {
 		_rcut = debyecut;
 		_sqr_rcut = debyecut * debyecut;
@@ -144,19 +136,6 @@ void RNA2Interaction::init() {
 
 	OX_LOG(Logger::LOG_INFO,"DEBUGGING: rhigh is %g, Cutoff is %g, RC huckel is %g, B huckel is %g, V is %g, lambda is %g ",_debye_huckel_RHIGH,_rcut,_debye_huckel_RC, _debye_huckel_B,_debye_huckel_Vrc,lambda);
 	OX_LOG(Logger::LOG_INFO,"DEBUGGING: dh_half_charged_ends = %s", _debye_huckel_half_charged_ends ? "true" : "false");
-
-//
-	/*
-	 printf("# B = %g\n",_debye_huckel_B);
-	 printf("# Rc = %g\n",_debye_huckel_RC);
-	 printf("# Rh = %g\n",_debye_huckel_RHIGH);
-	 for (double x = 0.01; x <= _debye_huckel_RC +0.02;  x += 0.02)
-	 {
-	 //energy = _debye_huckel(partic)
-	 printf("%g %g \n",x,test_huckel(x));
-	 }
-	 exit(1);
-	 */
 
 	if(_mismatch_repulsion) {
 		float temp = -1.0f * _RNA_HYDR_MIS / model->RNA_HYDR_EPS;
@@ -208,7 +187,6 @@ number RNA2Interaction::_debye_huckel(BaseParticle *p, BaseParticle *q, bool com
 			energy = _debye_huckel_B * SQR(rbackmod - _debye_huckel_RC);
 		}
 		energy *= cut_factor;
-		//update forces are NOT TESTED !!! NEEDS DEBUGGING+careful tests!!!
 		if(update_forces && energy != 0.) {
 			LR_vector force(0., 0., 0.);
 			LR_vector torqueq(0., 0., 0.);

--- a/src/Observables/BaseObservable.cpp
+++ b/src/Observables/BaseObservable.cpp
@@ -15,6 +15,10 @@ BaseObservable::~BaseObservable() {
 
 }
 
+bool BaseObservable::is_update_every_set() {
+	return _update_every > 0;
+}
+
 bool BaseObservable::need_updating(llint curr_step) {
 	return (_update_every > 0 && (curr_step % _update_every) == 0);
 }

--- a/src/Observables/BaseObservable.h
+++ b/src/Observables/BaseObservable.h
@@ -34,6 +34,10 @@ public:
 
 	virtual bool need_updating(llint curr_step);
 
+	virtual bool require_data_on_CPU() {
+		return true;
+	}
+
 	virtual void update_data(llint curr_step);
 
 	/**

--- a/src/Observables/BaseObservable.h
+++ b/src/Observables/BaseObservable.h
@@ -56,6 +56,10 @@ public:
 	 */
 	virtual void get_settings(input_file &my_inp, input_file &sim_inp);
 
+	virtual void serialise() {
+
+	}
+
 	/**
 	 * @brief Initializes the observable.
 	 */

--- a/src/Observables/BaseObservable.h
+++ b/src/Observables/BaseObservable.h
@@ -29,6 +29,8 @@ public:
 
 	virtual ~BaseObservable();
 
+	virtual bool is_update_every_set();
+
 	virtual bool need_updating(llint curr_step);
 
 	virtual void update_data(llint curr_step);

--- a/src/Observables/BaseObservable.h
+++ b/src/Observables/BaseObservable.h
@@ -24,12 +24,13 @@ protected:
 
 	std::string _id;
 	long long int _update_every = 0;
+	long long int _times_updated = 0;
 public:
 	BaseObservable();
 
 	virtual ~BaseObservable();
 
-	virtual bool is_update_every_set();
+	bool is_update_every_set();
 
 	virtual bool need_updating(llint curr_step);
 

--- a/src/Observables/ObservableOutput.cpp
+++ b/src/Observables/ObservableOutput.cpp
@@ -180,6 +180,10 @@ void ObservableOutput::print_output(llint step) {
 	stringstream ss;
 	for(auto it = _obss.begin(); it != _obss.end(); it++) {
 		if(it != _obss.begin()) ss << " ";
+
+		if(!(*it)->is_update_every_set()) {
+			(*it)->update_data(step);
+		}
 		ss << (*it)->get_output_string(step);
 	}
 

--- a/src/Observables/ObservableOutput.cpp
+++ b/src/Observables/ObservableOutput.cpp
@@ -181,6 +181,8 @@ void ObservableOutput::print_output(llint step) {
 	for(auto it = _obss.begin(); it != _obss.end(); it++) {
 		if(it != _obss.begin()) ss << " ";
 
+		// if "update_every" is not set we update the observable's data here
+		// otherwise it is updated by SimBackend::update_observables_data()
 		if(!(*it)->is_update_every_set()) {
 			(*it)->update_data(step);
 		}

--- a/src/Observables/Pressure.cpp
+++ b/src/Observables/Pressure.cpp
@@ -101,7 +101,6 @@ void Pressure::update_pressure() {
 }
 
 void Pressure::update_pressure_with_custom_stress_tensor() {
-	int N = _config_info->N();
 	std::vector<ParticlePair> pairs = _config_info->lists->get_potential_interactions();
 
 	_config_info->interaction->begin_energy_computation();
@@ -122,7 +121,7 @@ void Pressure::update_pressure_with_custom_stress_tensor() {
 	for(auto &v : _stress_tensor) {
 		v /= 3. * V;
 	}
-	_P = _config_info->temperature() * (N / V) + (_stress_tensor[0] + _stress_tensor[1] + _stress_tensor[2]);
+	_P = _stress_tensor[0] + _stress_tensor[1] + _stress_tensor[2];
 }
 
 std::string Pressure::get_output_string(llint curr_step) {

--- a/src/Observables/Pressure.cpp
+++ b/src/Observables/Pressure.cpp
@@ -11,9 +11,7 @@ Pressure::Pressure() :
 				BaseObservable(),
 				_custom_stress_tensor(true),
 				_with_stress_tensor(false),
-				_PV_only(false),
-				_P(0.),
-				_shear_rate(0.) {
+				_PV_only(false) {
 
 }
 
@@ -27,118 +25,28 @@ void Pressure::get_settings(input_file &my_inp, input_file &sim_inp) {
 	getInputBool(&my_inp, "custom_stress_tensor", &_custom_stress_tensor, 0);
 	getInputBool(&my_inp, "stress_tensor", &_with_stress_tensor, 0);
 	getInputBool(&my_inp, "PV_only", &_PV_only, 0);
-
-	bool lees_edwards = false;
-	getInputBool(&sim_inp, "lees_edwards", &lees_edwards, 0);
-	if(lees_edwards) getInputNumber(&sim_inp, "lees_edwards_shear_rate", &_shear_rate, 0);
-}
-
-void Pressure::update_pressure() {
-	std::vector<ParticlePair> pairs = _config_info->lists->get_potential_interactions();
-
-	_config_info->interaction->begin_energy_computation();
-
-	double virial = 0;
-	_stress_tensor = { 0., 0., 0., 0., 0., 0. };
-	double energy = 0.;
-	// we loop over all the pairs in order to update the forces
-	for(auto &pair : pairs) {
-		BaseParticle *p = pair.first;
-		BaseParticle *q = pair.second;
-		LR_vector r = _config_info->box->min_image(p->pos, q->pos);
-
-		// pair_interaction will change these vectors, but we still need them in the next
-		// first integration step. For this reason we copy and then restore their values
-		// after the calculation
-		LR_vector old_p_force(p->force);
-		LR_vector old_q_force(q->force);
-		LR_vector old_p_torque(p->torque);
-		LR_vector old_q_torque(q->torque);
-
-		p->force = q->force = p->torque = q->torque = LR_vector();
-
-		_config_info->interaction->set_computed_r(r);
-		energy += (double) _config_info->interaction->pair_interaction(p, q, false, true);
-
-		_stress_tensor[0] -= r.x * p->force.x;
-		_stress_tensor[1] -= r.y * p->force.y;
-		_stress_tensor[2] -= r.z * p->force.z;
-		_stress_tensor[3] -= r.x * p->force.y;
-		_stress_tensor[4] -= r.x * p->force.z;
-		_stress_tensor[5] -= r.y * p->force.z;
-
-		virial -= (r * p->force);
-
-		p->force = old_p_force;
-		q->force = old_q_force;
-		p->torque = old_p_torque;
-		q->torque = old_q_torque;
-	}
-
-	for(auto p : _config_info->particles()) {
-		LR_vector vel = p->vel;
-		if(_shear_rate > 0.) {
-			number Ly = CONFIG_INFO->box->box_sides().y;
-			number y_in_box = p->pos.y - floor(p->pos.y / Ly) * Ly - 0.5 * Ly;
-			number flow_vx = y_in_box * _shear_rate;
-			vel.x -= flow_vx;
-		}
-		_stress_tensor[0] += SQR(vel.x);
-		_stress_tensor[1] += SQR(vel.y);
-		_stress_tensor[2] += SQR(vel.z);
-		_stress_tensor[3] += vel.x * vel.y;
-		_stress_tensor[4] += vel.x * vel.z;
-		_stress_tensor[5] += vel.y * vel.z;
-
-		virial += vel.norm();
-	}
-
-	double V = (_PV_only) ? 1 : _config_info->box->V();
-	_P = virial / (3. * V);
-	for(auto &v : _stress_tensor) {
-		v /= 3. * V;
-	}
-}
-
-void Pressure::update_pressure_with_custom_stress_tensor() {
-	std::vector<ParticlePair> pairs = _config_info->lists->get_potential_interactions();
-
-	_config_info->interaction->begin_energy_computation();
-
-	for(auto p : _config_info->particles()) {
-		p->force = p->torque = LR_vector();
-	}
-
-	for(auto &pair : pairs) {
-		BaseParticle *p = pair.first;
-		BaseParticle *q = pair.second;
-
-		_config_info->interaction->pair_interaction(p, q, true, true);
-	}
-
-	double V = (_PV_only) ? 1 : _config_info->box->V();
-	_stress_tensor = _config_info->interaction->stress_tensor();
-	for(auto &v : _stress_tensor) {
-		v /= 3. * V;
-	}
-	_P = _stress_tensor[0] + _stress_tensor[1] + _stress_tensor[2];
 }
 
 std::string Pressure::get_output_string(llint curr_step) {
-	if(_custom_stress_tensor && _config_info->interaction->has_custom_stress_tensor()) {
-		update_pressure_with_custom_stress_tensor();
+	if(!_custom_stress_tensor || !_config_info->interaction->has_custom_stress_tensor()) {
+		_config_info->interaction->compute_standard_stress_tensor();
 	}
-	else {
-		update_pressure();
+
+	StressTensor stress_tensor = _config_info->interaction->stress_tensor();
+	if(_PV_only) {
+		for(auto &v : stress_tensor) {
+			v *= _config_info->box->V();
+		}
 	}
+	double P = (stress_tensor[0] + stress_tensor[1] + stress_tensor[2]) / 3.;
 
 	std::string to_ret;
 
 	if(_with_stress_tensor) {
-		to_ret += Utils::sformat("% .8e % .8e % .8e % .8e % .8e % .8e % .8e", _P, _stress_tensor[0], _stress_tensor[1], _stress_tensor[2], _stress_tensor[3], _stress_tensor[4], _stress_tensor[5]);
+		to_ret += Utils::sformat("% .8e % .8e % .8e % .8e % .8e % .8e % .8e", P, stress_tensor[0], stress_tensor[1], stress_tensor[2], stress_tensor[3], stress_tensor[4], stress_tensor[5]);
 	}
 	else {
-		to_ret += Utils::sformat("% .8e", _P);
+		to_ret += Utils::sformat("% .8e", P);
 	}
 
 	return to_ret;

--- a/src/Observables/Pressure.h
+++ b/src/Observables/Pressure.h
@@ -25,18 +25,12 @@ protected:
 	bool _custom_stress_tensor;
 	bool _with_stress_tensor;
 	bool _PV_only;
-	double _P;
-	StressTensor _stress_tensor;
-	number _shear_rate;
 
 public:
 	Pressure();
 	virtual ~Pressure();
 
 	void get_settings(input_file &my_inp, input_file &sim_inp);
-
-	void update_pressure();
-	void update_pressure_with_custom_stress_tensor();
 
 	std::string get_output_string(llint curr_step);
 };

--- a/src/Observables/Rdf.cpp
+++ b/src/Observables/Rdf.cpp
@@ -8,7 +8,8 @@
 #include "Rdf.h"
 
 Rdf::Rdf() {
-	_nconf = 0;
+	_n_confs = 0;
+	_n_pairs = 0;
 	_nbins = -1;
 	_bin_size = (number) -1.;
 	_max_value = (number) -1.;
@@ -20,20 +21,25 @@ Rdf::~Rdf() {
 
 }
 
-std::string Rdf::get_output_string(llint curr_step) {
+void Rdf::update_data(llint curr_step) {
 	int N = _config_info->N();
 
 	// get smallest side
 	LR_vector sides = _config_info->box->box_sides();
 	number box_side = sides[0];
-	if(sides[1] < box_side) box_side = sides[1];
-	if(sides[2] < box_side) box_side = sides[2];
+	if(sides[1] < box_side) {
+		box_side = sides[1];
+	}
 
-	_nconf += 1;
+	if(sides[2] < box_side) {
+		box_side = sides[2];
+	}
 
-	if(_max_value > box_side / 2. && _nconf == 1) OX_LOG(Logger::LOG_WARNING, "Observable Rdf: computing profile with max_value > box_size/2. (%g > %g/2.)", _max_value, box_side);
+	_n_confs += 1;
 
-	int n_pairs = 0;
+	if(_max_value > box_side / 2. && _n_confs == 1) OX_LOG(Logger::LOG_WARNING, "Observable Rdf: computing profile with max_value > box_size/2. (%g > %g/2.)", _max_value, box_side);
+
+	_n_pairs = 0;
 	for(int i = 0; i < N; i++) {
 		BaseParticle *p = _config_info->particles()[i];
 		for(int j = 0; j < i; j++) {
@@ -47,15 +53,17 @@ std::string Rdf::get_output_string(llint curr_step) {
 					int mybin = (int) (0.01 + floor(drmod / _bin_size));
 					_profile[mybin] += 1.;
 				}
-				n_pairs++;
+				_n_pairs++;
 			}
 		}
 	}
+}
 
+std::string Rdf::get_output_string(llint curr_step) {
 	std::stringstream ret;
 	ret.precision(9);
 	double myx = _bin_size / 2.;
-	double norm_factor = 4 * M_PI * _nconf * n_pairs * _bin_size / _config_info->box->V();
+	double norm_factor = 4 * M_PI * _n_confs * _n_pairs * _bin_size / _config_info->box->V();
 	for(auto value: _profile) {
 		ret << myx << " " << value / (norm_factor * myx * myx) << std::endl;
 		myx += _bin_size;

--- a/src/Observables/Rdf.cpp
+++ b/src/Observables/Rdf.cpp
@@ -8,7 +8,6 @@
 #include "Rdf.h"
 
 Rdf::Rdf() {
-	_n_confs = 0;
 	_n_pairs = 0;
 	_nbins = -1;
 	_bin_size = (number) -1.;
@@ -35,9 +34,8 @@ void Rdf::update_data(llint curr_step) {
 		box_side = sides[2];
 	}
 
-	_n_confs += 1;
-
-	if(_max_value > box_side / 2. && _n_confs == 1) OX_LOG(Logger::LOG_WARNING, "Observable Rdf: computing profile with max_value > box_size/2. (%g > %g/2.)", _max_value, box_side);
+	_times_updated++;
+	if(_max_value > box_side / 2. && _times_updated == 1) OX_LOG(Logger::LOG_WARNING, "Observable Rdf: computing profile with max_value > box_size/2. (%g > %g/2.)", _max_value, box_side);
 
 	_n_pairs = 0;
 	for(int i = 0; i < N; i++) {
@@ -63,7 +61,7 @@ std::string Rdf::get_output_string(llint curr_step) {
 	std::stringstream ret;
 	ret.precision(9);
 	double myx = _bin_size / 2.;
-	double norm_factor = 4 * M_PI * _n_confs * _n_pairs * _bin_size / _config_info->box->V();
+	double norm_factor = 4 * M_PI * _times_updated * _n_pairs * _bin_size / _config_info->box->V();
 	for(auto value: _profile) {
 		ret << myx << " " << value / (norm_factor * myx * myx) << std::endl;
 		myx += _bin_size;

--- a/src/Observables/Rdf.h
+++ b/src/Observables/Rdf.h
@@ -45,7 +45,6 @@
  */
 class Rdf: public BaseObservable {
 private:
-	long int _n_confs;
 	int _n_pairs;
 	number _max_value;
 	number _bin_size;

--- a/src/Observables/Rdf.h
+++ b/src/Observables/Rdf.h
@@ -45,7 +45,8 @@
  */
 class Rdf: public BaseObservable {
 private:
-	long int _nconf;
+	long int _n_confs;
+	int _n_pairs;
 	number _max_value;
 	number _bin_size;
 	int _nbins;
@@ -57,7 +58,10 @@ public:
 	Rdf();
 	virtual ~Rdf();
 
-	virtual std::string get_output_string(llint curr_step);
+	void update_data(llint curr_step) override;
+
+	std::string get_output_string(llint curr_step) override;
+
 	void get_settings(input_file &my_inp, input_file &sim_inp);
 };
 

--- a/src/Observables/StressAutocorrelation.cpp
+++ b/src/Observables/StressAutocorrelation.cpp
@@ -18,7 +18,7 @@ StressAutocorrelation::~StressAutocorrelation() {
 
 }
 
-void StressAutocorrelation::_serialise() {
+void StressAutocorrelation::serialise() {
 	_sigma_xy->serialise("sigma_xy.dat");
 	_sigma_yz->serialise("sigma_yz.dat");
 	_sigma_xz->serialise("sigma_xz.dat");
@@ -119,10 +119,6 @@ std::string StressAutocorrelation::get_output_string(llint curr_step) {
 		Gt += V / (30. * T) * (acf_N_xy[i] + acf_N_xz[i] + acf_N_yz[i]);
 
 		ss << times[i] << Utils::sformat(" %.8e", Gt) << std::endl;
-	}
-
-	if(_enable_serialisation) {
-		_serialise();
 	}
 
 	return ss.str();

--- a/src/Observables/StressAutocorrelation.cpp
+++ b/src/Observables/StressAutocorrelation.cpp
@@ -18,6 +18,32 @@ StressAutocorrelation::~StressAutocorrelation() {
 
 }
 
+void StressAutocorrelation::_serialise() {
+	_sigma_xy->serialise("sigma_xy.dat");
+	_sigma_yz->serialise("sigma_yz.dat");
+	_sigma_xz->serialise("sigma_xz.dat");
+
+	_N_xy->serialise("N_xy.dat");
+	_N_xy->serialise("N_yz.dat");
+	_N_xy->serialise("N_zx.dat");
+}
+
+std::shared_ptr<StressAutocorrelation::Level> StressAutocorrelation::_deserialise(std::string filename, uint m, uint p) {
+	std::shared_ptr<Level> res;
+
+	std::ifstream inp(filename);
+	if(inp) {
+		res = std::make_shared<Level>(inp);
+		inp.close();
+	}
+	else {
+		OX_LOG(Logger::LOG_WARNING, "StressAutocorrelation: file '%s.dat' not found", filename.c_str());
+		res = std::make_shared<Level>(m, p, 0);
+	}
+
+	return res;
+}
+
 void StressAutocorrelation::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
@@ -30,87 +56,41 @@ void StressAutocorrelation::get_settings(input_file &my_inp, input_file &sim_inp
 	getInputDouble(&sim_inp, "dt", &_delta_t, 1);
 	_delta_t *= _update_every;
 
-	_sigma_xy = std::make_shared<Level>(m, p, 0);
-	_sigma_yz = std::make_shared<Level>(m, p, 0);
-	_sigma_zx = std::make_shared<Level>(m, p, 0);
-	_N_xy = std::make_shared<Level>(m, p, 0);
-	_N_yz = std::make_shared<Level>(m, p, 0);
-	_N_xz = std::make_shared<Level>(m, p, 0);
+	getInputBool(&my_inp, "serialise", &_enable_serialisation, 0);
+
+	if(_enable_serialisation) {
+		_sigma_xy = _deserialise("sigma_xy.dat", m, p);
+		_sigma_yz = _deserialise("sigma_yz.dat", m, p);
+		_sigma_xz = _deserialise("sigma_xz.dat", m, p);
+
+		_N_xy = _deserialise("N_xy.dat", m, p);
+		_N_yz = _deserialise("N_yz.dat", m, p);
+		_N_xz = _deserialise("N_zx.dat", m, p);
+	}
+	else {
+		_sigma_xy = std::make_shared<Level>(m, p, 0);
+		_sigma_yz = std::make_shared<Level>(m, p, 0);
+		_sigma_xz = std::make_shared<Level>(m, p, 0);
+		_N_xy = std::make_shared<Level>(m, p, 0);
+		_N_yz = std::make_shared<Level>(m, p, 0);
+		_N_xz = std::make_shared<Level>(m, p, 0);
+	}
+}
+
+bool StressAutocorrelation::require_data_on_CPU() {
+	return false;
 }
 
 void StressAutocorrelation::update_data(llint curr_step) {
-	_config_info->interaction->begin_energy_computation();
-
-	// pair_interaction will change these vectors, but we still need them in the next
-	// first integration step. For this reason we copy and then restore their values
-	// after the calculation
-	_old_forces.resize(_config_info->N());
-	_old_torques.resize(_config_info->N());
-	for(int i = 0; i < _config_info->N(); i++) {
-		_old_forces[i] = _config_info->particles()[i]->force;
-		_old_torques[i] = _config_info->particles()[i]->torque;
+	if(!_config_info->interaction->has_custom_stress_tensor()) {
+		_config_info->interaction->compute_standard_stress_tensor();
 	}
 
-	StressTensor stress_tensor = { 0., 0., 0., 0., 0., 0. };
-	double energy = 0.;
-
-	for(auto p : _config_info->particles()) {
-		std::vector<BaseParticle *> neighs = _config_info->lists->get_neigh_list(p);
-
-		std::set<BaseParticle *> bonded_neighs;
-		for(auto &pair : p->affected) {
-			if(pair.first != p) {
-				bonded_neighs.insert(pair.first);
-			}
-			if(pair.second != p) {
-				bonded_neighs.insert(pair.second);
-			}
-		}
-
-		neighs.insert(neighs.end(), bonded_neighs.begin(), bonded_neighs.end());
-
-		for(auto q : neighs) {
-			if(p->index > q->index) {
-				LR_vector r = _config_info->box->min_image(p->pos, q->pos);
-				_config_info->interaction->set_computed_r(r);
-
-				p->force = LR_vector();
-				energy += (double) _config_info->interaction->pair_interaction(p, q, false, true);
-
-				stress_tensor[0] -= r.x * p->force.x;
-				stress_tensor[1] -= r.y * p->force.y;
-				stress_tensor[2] -= r.z * p->force.z;
-				stress_tensor[3] -= r.x * p->force.y;
-				stress_tensor[4] -= r.x * p->force.z;
-				stress_tensor[5] -= r.y * p->force.z;
-			}
-		}
-	}
-
-	for(int i = 0; i < _config_info->N(); i++) {
-		auto p = _config_info->particles()[i];
-
-		p->force = _old_forces[i];
-		p->torque = _old_torques[i];
-
-		LR_vector vel = p->vel;
-
-		stress_tensor[0] += SQR(vel.x);
-		stress_tensor[1] += SQR(vel.y);
-		stress_tensor[2] += SQR(vel.z);
-		stress_tensor[3] += vel.x * vel.y;
-		stress_tensor[4] += vel.x * vel.z;
-		stress_tensor[5] += vel.y * vel.z;
-	}
-
-	double V = _config_info->box->V();
-	for(auto &v : stress_tensor) {
-		v /= V;
-	}
+	StressTensor stress_tensor = _config_info->interaction->stress_tensor();
 
 	_sigma_xy->add_value(stress_tensor[3]);
 	_sigma_yz->add_value(stress_tensor[5]);
-	_sigma_zx->add_value(stress_tensor[4]);
+	_sigma_xz->add_value(stress_tensor[4]);
 
 	_N_xy->add_value(stress_tensor[0] - stress_tensor[1]);
 	_N_xz->add_value(stress_tensor[0] - stress_tensor[2]);
@@ -126,7 +106,7 @@ std::string StressAutocorrelation::get_output_string(llint curr_step) {
 	std::vector<double> acf_sigma_xy, acf_sigma_yz, acf_sigma_zx, acf_N_xy, acf_N_xz, acf_N_yz;
 	_sigma_xy->get_acf(_delta_t, acf_sigma_xy);
 	_sigma_yz->get_acf(_delta_t, acf_sigma_yz);
-	_sigma_zx->get_acf(_delta_t, acf_sigma_zx);
+	_sigma_xz->get_acf(_delta_t, acf_sigma_zx);
 
 	_N_xy->get_acf(_delta_t, acf_N_xy);
 	_N_xz->get_acf(_delta_t, acf_N_xz);
@@ -138,7 +118,11 @@ std::string StressAutocorrelation::get_output_string(llint curr_step) {
 		double Gt = V / (5. * T) * (acf_sigma_xy[i] + acf_sigma_yz[i] + acf_sigma_zx[i]);
 		Gt += V / (30. * T) * (acf_N_xy[i] + acf_N_xz[i] + acf_N_yz[i]);
 
-		ss << times[i] << " " << Gt << std::endl;
+		ss << times[i] << Utils::sformat(" %.8e", Gt) << std::endl;
+	}
+
+	if(_enable_serialisation) {
+		_serialise();
 	}
 
 	return ss.str();

--- a/src/Observables/StressAutocorrelation.cpp
+++ b/src/Observables/StressAutocorrelation.cpp
@@ -39,7 +39,6 @@ void StressAutocorrelation::get_settings(input_file &my_inp, input_file &sim_inp
 }
 
 void StressAutocorrelation::update_data(llint curr_step) {
-
 	_config_info->interaction->begin_energy_computation();
 
 	// pair_interaction will change these vectors, but we still need them in the next

--- a/src/Observables/StressAutocorrelation.h
+++ b/src/Observables/StressAutocorrelation.h
@@ -172,7 +172,7 @@ protected:
 	uint _m = 2;
 	uint _p = 16;
 	std::vector<LR_vector> _old_forces, _old_torques;
-	std::shared_ptr<Level> _sigma_xy, _sigma_yz, _sigma_xz, _N_xy, _N_yz, _N_xz;
+	std::shared_ptr<Level> _sigma_xy, _sigma_yz, _sigma_xz, _N_xy, _N_yz, _N_xz, _sigma_xx, _sigma_yy, _sigma_zz, _sigma_P;
 	double _delta_t = 0.0;
 	bool _enable_serialisation = false;
 

--- a/src/Observables/StressAutocorrelation.h
+++ b/src/Observables/StressAutocorrelation.h
@@ -46,18 +46,7 @@ class StressAutocorrelation: public BaseObservable {
 			start_at = (l_number == 0) ? 0 : p / m;
 		}
 
-		Level(std::string filename) {
-			std::ifstream inp(filename);
-			load_from_file(inp);
-			inp.close();
-		}
-
-		Level(std::istream &inp) {
-			load_from_file(inp);
-		}
-
 		void load_from_file(std::istream &inp) {
-			inp.ignore(32768, '\n');
 			inp >> m;
 			inp >> p;
 			inp >> level_number;
@@ -86,7 +75,8 @@ class StressAutocorrelation: public BaseObservable {
 			inp >> next_p;
 			if(inp.good()) {
 				inp.seekg(pos);
-				next = std::make_shared<Level>(inp);
+				next = std::make_shared<Level>(m, p, level_number + 1);
+				next->load_from_file(inp);
 			}
 		}
 
@@ -179,18 +169,21 @@ class StressAutocorrelation: public BaseObservable {
 	};
 
 protected:
+	uint _m = 2;
+	uint _p = 16;
 	std::vector<LR_vector> _old_forces, _old_torques;
 	std::shared_ptr<Level> _sigma_xy, _sigma_yz, _sigma_xz, _N_xy, _N_yz, _N_xz;
 	double _delta_t = 0.0;
 	bool _enable_serialisation = false;
 
-	std::shared_ptr<Level> _deserialise(std::string filename, uint m, uint p);
+	std::shared_ptr<Level> _deserialise(std::string filename);
 
 public:
 	StressAutocorrelation();
 	virtual ~StressAutocorrelation();
 
 	void get_settings(input_file &my_inp, input_file &sim_inp);
+	void init() override;
 
 	void serialise() override;
 

--- a/src/Observables/StressAutocorrelation.h
+++ b/src/Observables/StressAutocorrelation.h
@@ -57,6 +57,7 @@ class StressAutocorrelation: public BaseObservable {
 		}
 
 		void load_from_file(std::istream &inp) {
+			inp.ignore(32768, '\n');
 			inp >> m;
 			inp >> p;
 			inp >> level_number;
@@ -170,6 +171,7 @@ class StressAutocorrelation: public BaseObservable {
 		void serialise(std::string filename) {
 			std::ofstream output(filename);
 
+			output << "t = " << CONFIG_INFO->curr_step << std::endl;
 			output << _serialised();
 
 			output.close();
@@ -182,7 +184,6 @@ protected:
 	double _delta_t = 0.0;
 	bool _enable_serialisation = false;
 
-	void _serialise();
 	std::shared_ptr<Level> _deserialise(std::string filename, uint m, uint p);
 
 public:
@@ -190,6 +191,8 @@ public:
 	virtual ~StressAutocorrelation();
 
 	void get_settings(input_file &my_inp, input_file &sim_inp);
+
+	void serialise() override;
 
 	bool require_data_on_CPU() override;
 	void update_data(llint curr_step) override;

--- a/src/Observables/StressAutocorrelation.h
+++ b/src/Observables/StressAutocorrelation.h
@@ -93,7 +93,7 @@ class StressAutocorrelation: public BaseObservable {
 protected:
 	std::vector<LR_vector> _old_forces, _old_torques;
 	std::shared_ptr<Level> _sigma_xy, _sigma_yz, _sigma_zx, _N_xy, _N_yz, _N_xz;
-	double _delta_t;
+	double _delta_t = 0.0;
 
 public:
 	StressAutocorrelation();

--- a/src/Observables/StructureFactor.cpp
+++ b/src/Observables/StructureFactor.cpp
@@ -10,11 +10,11 @@
 #include <algorithm>
 
 StructureFactor::StructureFactor() {
-	_nconf = 0;
 	_type = -1;
 	_max_qs_in_interval = 30;
 	_max_qs_delta = 0.001;
 	_always_reset = false;
+	_max_q = 10;
 }
 
 StructureFactor::~StructureFactor() {
@@ -103,7 +103,7 @@ void StructureFactor::update_data(llint curr_step) {
 
 		_sq[nq] += (SQR(sq_cos) + SQR(sq_sin)) / N_type;
 	}
-	_nconf++;
+	_times_updated++;
 }
 
 std::string StructureFactor::get_output_string(llint curr_step) {
@@ -127,7 +127,7 @@ std::string StructureFactor::get_output_string(llint curr_step) {
 		it++;
 		if(nq + 1 == _qs.size() || fabs(it->norm() - SQR(first_q)) > _max_qs_delta) {
 			avg_q_mod /= q_count;
-			sq_mean /= q_count * _nconf;
+			sq_mean /= q_count * _times_updated;
 			ret << avg_q_mod << " " << sq_mean << std::endl;
 			q_count = 0;
 			avg_q_mod = sq_mean = 0.;
@@ -136,7 +136,7 @@ std::string StructureFactor::get_output_string(llint curr_step) {
 	}
 
 	if(_always_reset) {
-		_nconf = 0;
+		_times_updated = 0;
 		std::fill(_sq.begin(), _sq.end(), 0.);
 	}
 

--- a/src/Observables/StructureFactor.h
+++ b/src/Observables/StructureFactor.h
@@ -41,7 +41,6 @@ max_q = 6.
 
 class StructureFactor : public BaseObservable {
 private:
-	long int _nconf;
 	number _max_q;
 	std::vector<long double> _sq, _sq_cos, _sq_sin;
 	std::list<LR_vector> _qs;
@@ -54,10 +53,11 @@ public:
 	StructureFactor();
 	virtual ~StructureFactor();
 
-	void get_settings(input_file &my_inp, input_file &sim_inp);
-	virtual void init();
+	void get_settings(input_file &my_inp, input_file &sim_inp) override;
+	void init() override;
 
 	void update_data(llint curr_step) override;
+
 	std::string get_output_string(llint curr_step) override;
 };
 

--- a/src/Utilities/LR_vector.h
+++ b/src/Utilities/LR_vector.h
@@ -120,6 +120,14 @@ public:
 		return std::sqrt(sqr_distance(V1));
 	}
 
+	inline LR_vector stably_normalised() {
+		LR_vector res(*this);
+
+		number max = std::fmax(std::fmax(std::fabs(x), std::fabs(y)), std::fabs(z));
+		res /= max;
+		return res /  res.module();
+	}
+
 	inline void normalize() {
 		number v_norm = norm();
 		if(v_norm == 0) return;

--- a/src/defs.h
+++ b/src/defs.h
@@ -41,8 +41,10 @@
 
 #include <string>
 #include <memory>
+#include <array>
 
 using uint = uint32_t;
 using llint = long long int;
+using StressTensor = std::array<number, 6>;
 
 #endif /* DEFS_H_ */


### PR DESCRIPTION
This quite large PR contains several seemingly unrelated changes that

1. slightly simplify the writing of new CUDA interactions
2. make it possible to compute the stress tensor on CUDA in a rather efficient manner
3. make it possible to "serialise" (i.e. dump the internal status of) observables. This can be useful when restarting simulations
4. improve the performance of DNA/RNA CUDA simulations by decreasing register and memory usage
5. fix a subtle bug that slighy decreased numerical stability of DNA and RNA CUDA simulations