### PR TITLE
Shift harmonic force pos the same way as NT pos

### DIFF
--- a/src/CUDA/Backends/MD_CUDABackend.cu
+++ b/src/CUDA/Backends/MD_CUDABackend.cu
@@ -149,7 +149,7 @@ void MD_CUDABackend::_apply_external_forces_changes() {
 				}
 				else if(force_type == typeid(MovingTrap)) {
 					MovingTrap *p_force = (MovingTrap *) p->ext_forces[j];
-					init_MovingTrap_from_CPU(&cuda_force->moving, p_force);
+					init_MovingTrap_from_CPU(&cuda_force->moving, p_force, p->_pos_shift, _box->box_sides());
 				}
 				else if(force_type == typeid(LowdimMovingTrap)) {
 					LowdimMovingTrap *p_force = (LowdimMovingTrap *) p->ext_forces[j];

--- a/src/CUDA/CUDAForces.h
+++ b/src/CUDA/CUDAForces.h
@@ -99,11 +99,11 @@ struct moving_trap {
 	float3 dir;
 };
 
-void init_MovingTrap_from_CPU(moving_trap *cuda_force, MovingTrap *cpu_force) {
+void init_MovingTrap_from_CPU(moving_trap *cuda_force, MovingTrap *cpu_force, const int *p_pos_shift, const LR_vector &box_sides) {
 	cuda_force->type = CUDA_TRAP_MOVING;
 	cuda_force->stiff = cpu_force->_stiff;
 	cuda_force->rate = cpu_force->_rate;
-	cuda_force->pos0 = make_float3(cpu_force->_pos0.x, cpu_force->_pos0.y, cpu_force->_pos0.z);
+	cuda_force->pos0 = make_float3(cpu_force->_pos0.x - box_sides.x * p_pos_shift[0], cpu_force->_pos0.y - box_sides.y * p_pos_shift[1], cpu_force->_pos0.z - box_sides.z * p_pos_shift[2]);
 	cuda_force->dir = make_float3(cpu_force->_direction.x, cpu_force->_direction.y, cpu_force->_direction.z);
 }
 


### PR DESCRIPTION
Fix #71.

Hi Lorenzo, Thanks for the guidance on the issue. I believe this PR fixes it. Below is a short description of what's happening. 

https://github.com/lorenzo-rovigatti/oxDNA/blob/a6214b99b64806d322e110c3d84fce4bbe9815f2/src/Backends/SimBackend.cpp#L535-L542

The above code snippet is executed if `fix_diffusion = true` even at `step == 0`. It means the positions of NTs might be shifted at the very beginning. This makes it hard to set the `pos0` parameter for harmonic traps. This PR solves the issue by shifting the `pos0` of the external forces of an NT using its recorded `p->_pos_shift` and the box sides. The attached files in #71 can be used to test the issue and the fix. 

I believe the "rotating harmonic trap" will suffer from the same issue. But I do not have a use case to test. So, I have only fixed the "harmonic trap". If this PR is accepted, the same fix might need to be applied to the "rotating harmonic trap". 