### PR TITLE
Added non-mandatory option 'precision' to the ForceEnergy and PotentalEnergy observables

### DIFF
--- a/src/Observables/ForceEnergy.cpp
+++ b/src/Observables/ForceEnergy.cpp
@@ -19,6 +19,7 @@ void ForceEnergy::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
 	getInputString(&my_inp, "print_group", _group_name, 0);
+	getInputString(&my_inp, "precision", _precision, 0);
 }
 
 std::string ForceEnergy::get_output_string(llint curr_step) {
@@ -37,5 +38,10 @@ std::string ForceEnergy::get_output_string(llint curr_step) {
 	}
 	U /= _config_info->N();
 
-	return Utils::sformat("% 10.6lf", U);
+	if (_precision == "") {
+		return Utils::sformat("% 10.6lf", U);
+	}
+	else {
+		return Utils::sformat("% 10." + _precision + "lf", U);
+	}
 }

--- a/src/Observables/ForceEnergy.h
+++ b/src/Observables/ForceEnergy.h
@@ -22,6 +22,7 @@
 class ForceEnergy: public BaseObservable {
 protected:
 	std::string _group_name;
+	std::string _precision;
 public:
 	ForceEnergy();
 	virtual ~ForceEnergy();

--- a/src/Observables/PotentialEnergy.cpp
+++ b/src/Observables/PotentialEnergy.cpp
@@ -32,20 +32,31 @@ void PotentialEnergy::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
 	getInputBool(&my_inp, "split", &_split, 0);
+	getInputString(&my_inp, "precision", _precision, 0);
 }
 
 std::string PotentialEnergy::get_output_string(llint curr_step) {
 	if(!_split) {
 		number energy = get_potential_energy();
 
-		return Utils::sformat("% 10.6lf", energy);
+		if (_precision == "") {
+			return Utils::sformat("% 10.6lf", energy);
+		}
+		else {
+			return Utils::sformat("% 10." + _precision + "lf", energy);
+		}
 	}
 	else {
 		std::string res("");
 		auto energies = _config_info->interaction->get_system_energy_split(_config_info->particles(), _config_info->lists);
 		for(auto energy_item : energies) {
 			number contrib = energy_item.second / _config_info->N();
-			res = Utils::sformat("%s % 10.6lf", res.c_str(), contrib);
+			if (_precision == "") {
+				res = Utils::sformat("%s % 10.6lf", res.c_str(), contrib);
+			}
+			else{
+				return Utils::sformat("% 10." + _precision + "lf", res.c_str(), contrib);
+			}
 		}
 
 		return res;

--- a/src/Observables/PotentialEnergy.h
+++ b/src/Observables/PotentialEnergy.h
@@ -24,6 +24,8 @@
 class PotentialEnergy: public BaseObservable {
 protected:
 	bool _split;
+	std::string _precision;
+
 public:
 	PotentialEnergy();
 	virtual ~PotentialEnergy();


### PR DESCRIPTION
Motivation: the energy of an external force applied to a particle in an origami size system becomes 0.0 with the currently implemented precision when divided out by the number of particles, especially when you have multiple groups. Having the option to change the precision of Potential Energy obs is nice for when you split the contributions.