### PR TITLE
Add 'precision' non-mandatory option for ForceEnergy and PotentialEnergy observables

### DIFF
--- a/src/Observables/BaseObservable.cpp
+++ b/src/Observables/BaseObservable.cpp
@@ -30,8 +30,15 @@ void BaseObservable::update_data(llint curr_step) {
 void BaseObservable::get_settings(input_file &my_inp, input_file &sim_inp) {
 	getInputString(&my_inp, "id", _id, 0);
 	getInputLLInt(&my_inp, "update_every", &_update_every, 0);
-	getInputString(&my_inp, "precision", _precision, 0);
+	getInputLLInt(&my_inp, "precision", &_precision, 0);
 	getInputBool(&my_inp, "general_format", &_general_format, 0);
+
+	if (_general_format) {
+		_number_formatter = Utils::sformat("%%.%dg", _precision);
+	}
+	else {
+		_number_formatter = Utils::sformat("%%10.%dlf", _precision);
+	}
 }
 
 void BaseObservable::init() {

--- a/src/Observables/BaseObservable.cpp
+++ b/src/Observables/BaseObservable.cpp
@@ -30,6 +30,8 @@ void BaseObservable::update_data(llint curr_step) {
 void BaseObservable::get_settings(input_file &my_inp, input_file &sim_inp) {
 	getInputString(&my_inp, "id", _id, 0);
 	getInputLLInt(&my_inp, "update_every", &_update_every, 0);
+	getInputString(&my_inp, "precision", _precision, 0);
+	getInputBool(&my_inp, "general_format", &_general_format, 0);
 }
 
 void BaseObservable::init() {

--- a/src/Observables/BaseObservable.h
+++ b/src/Observables/BaseObservable.h
@@ -23,6 +23,8 @@ protected:
 	ConfigInfo *_config_info;
 
 	std::string _id;
+	bool _general_format = false;
+	std::string _precision = "6";
 	long long int _update_every = 0;
 	long long int _times_updated = 0;
 public:

--- a/src/Observables/BaseObservable.h
+++ b/src/Observables/BaseObservable.h
@@ -24,7 +24,8 @@ protected:
 
 	std::string _id;
 	bool _general_format = false;
-	std::string _precision = "6";
+	std::string _number_formatter;
+	long long int _precision = 6;
 	long long int _update_every = 0;
 	long long int _times_updated = 0;
 public:

--- a/src/Observables/ForceEnergy.cpp
+++ b/src/Observables/ForceEnergy.cpp
@@ -19,6 +19,7 @@ void ForceEnergy::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
 	getInputString(&my_inp, "print_group", _group_name, 0);
+	getInputString(&my_inp, "precision", _precision, 0);
 }
 
 std::string ForceEnergy::get_output_string(llint curr_step) {
@@ -37,5 +38,10 @@ std::string ForceEnergy::get_output_string(llint curr_step) {
 	}
 	U /= _config_info->N();
 
-	return Utils::sformat("% 10.6lf", U);
+	if (_precision == "") {
+		return Utils::sformat("% 10.6lf", U);
+	}
+	else {
+		return Utils::sformat("% 10." + _precision + "lf", U);
+	}
 }

--- a/src/Observables/ForceEnergy.cpp
+++ b/src/Observables/ForceEnergy.cpp
@@ -39,9 +39,9 @@ std::string ForceEnergy::get_output_string(llint curr_step) {
 	U /= _config_info->N();
 
 	if (_precision == "") {
-		return Utils::sformat("% 10.6lf", U);
+		return Utils::sformat("%g", U);
 	}
 	else {
-		return Utils::sformat("% 10." + _precision + "lf", U);
+		return Utils::sformat("%." + _precision + "g", U);
 	}
 }

--- a/src/Observables/ForceEnergy.cpp
+++ b/src/Observables/ForceEnergy.cpp
@@ -19,7 +19,6 @@ void ForceEnergy::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
 	getInputString(&my_inp, "print_group", _group_name, 0);
-	getInputString(&my_inp, "precision", _precision, 0);
 }
 
 std::string ForceEnergy::get_output_string(llint curr_step) {
@@ -38,10 +37,10 @@ std::string ForceEnergy::get_output_string(llint curr_step) {
 	}
 	U /= _config_info->N();
 
-	if (_precision == "") {
-		return Utils::sformat("%g", U);
+	if (_general_format) {
+		return Utils::sformat("%." + _precision + "g", U);
 	}
 	else {
-		return Utils::sformat("%." + _precision + "g", U);
+		return Utils::sformat("% 10." + _precision + "lf", U);
 	}
 }

--- a/src/Observables/ForceEnergy.cpp
+++ b/src/Observables/ForceEnergy.cpp
@@ -37,10 +37,5 @@ std::string ForceEnergy::get_output_string(llint curr_step) {
 	}
 	U /= _config_info->N();
 
-	if (_general_format) {
-		return Utils::sformat("%." + _precision + "g", U);
-	}
-	else {
-		return Utils::sformat("% 10." + _precision + "lf", U);
-	}
+	return Utils::sformat(_number_formatter, U);
 }

--- a/src/Observables/ForceEnergy.h
+++ b/src/Observables/ForceEnergy.h
@@ -22,7 +22,6 @@
 class ForceEnergy: public BaseObservable {
 protected:
 	std::string _group_name;
-	std::string _precision;
 public:
 	ForceEnergy();
 	virtual ~ForceEnergy();

--- a/src/Observables/ForceEnergy.h
+++ b/src/Observables/ForceEnergy.h
@@ -22,6 +22,7 @@
 class ForceEnergy: public BaseObservable {
 protected:
 	std::string _group_name;
+	std::string _precision;
 public:
 	ForceEnergy();
 	virtual ~ForceEnergy();

--- a/src/Observables/PotentialEnergy.cpp
+++ b/src/Observables/PotentialEnergy.cpp
@@ -40,10 +40,10 @@ std::string PotentialEnergy::get_output_string(llint curr_step) {
 		number energy = get_potential_energy();
 
 		if (_precision == "") {
-			return Utils::sformat("% 10.6lf", energy);
+			return Utils::sformat("%g", energy);
 		}
 		else {
-			return Utils::sformat("% 10." + _precision + "lf", energy);
+			return Utils::sformat("%." + _precision + "g", energy);
 		}
 	}
 	else {
@@ -52,10 +52,10 @@ std::string PotentialEnergy::get_output_string(llint curr_step) {
 		for(auto energy_item : energies) {
 			number contrib = energy_item.second / _config_info->N();
 			if (_precision == "") {
-				res = Utils::sformat("%s % 10.6lf", res.c_str(), contrib);
+				res = Utils::sformat("%s %g", res.c_str(), contrib);
 			}
 			else {
-				res = Utils::sformat("%s % 10." + _precision + "lf", res.c_str(), contrib);
+				res = Utils::sformat("%s %." + _precision + "g", res.c_str(), contrib);
 			}
 		}
 

--- a/src/Observables/PotentialEnergy.cpp
+++ b/src/Observables/PotentialEnergy.cpp
@@ -32,18 +32,17 @@ void PotentialEnergy::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
 	getInputBool(&my_inp, "split", &_split, 0);
-	getInputString(&my_inp, "precision", _precision, 0);
 }
 
 std::string PotentialEnergy::get_output_string(llint curr_step) {
 	if(!_split) {
 		number energy = get_potential_energy();
 
-		if (_precision == "") {
-			return Utils::sformat("%g", energy);
+		if (_general_format) {
+			return Utils::sformat("%." + _precision + "g", energy);
 		}
 		else {
-			return Utils::sformat("%." + _precision + "g", energy);
+			return Utils::sformat("% 10." + _precision + "lf", energy);
 		}
 	}
 	else {
@@ -51,11 +50,11 @@ std::string PotentialEnergy::get_output_string(llint curr_step) {
 		auto energies = _config_info->interaction->get_system_energy_split(_config_info->particles(), _config_info->lists);
 		for(auto energy_item : energies) {
 			number contrib = energy_item.second / _config_info->N();
-			if (_precision == "") {
-				res = Utils::sformat("%s %g", res.c_str(), contrib);
+			if (_general_format) {
+				res = Utils::sformat("%s %." + _precision + "g", res.c_str(), contrib);
 			}
 			else {
-				res = Utils::sformat("%s %." + _precision + "g", res.c_str(), contrib);
+				res = Utils::sformat("%s % 10." + _precision + "lf", res.c_str(), contrib);
 			}
 		}
 

--- a/src/Observables/PotentialEnergy.cpp
+++ b/src/Observables/PotentialEnergy.cpp
@@ -38,24 +38,14 @@ std::string PotentialEnergy::get_output_string(llint curr_step) {
 	if(!_split) {
 		number energy = get_potential_energy();
 
-		if (_general_format) {
-			return Utils::sformat("%." + _precision + "g", energy);
-		}
-		else {
-			return Utils::sformat("% 10." + _precision + "lf", energy);
-		}
+		return Utils::sformat(_number_formatter, energy);
 	}
 	else {
 		std::string res("");
 		auto energies = _config_info->interaction->get_system_energy_split(_config_info->particles(), _config_info->lists);
 		for(auto energy_item : energies) {
 			number contrib = energy_item.second / _config_info->N();
-			if (_general_format) {
-				res = Utils::sformat("%s %." + _precision + "g", res.c_str(), contrib);
-			}
-			else {
-				res = Utils::sformat("%s % 10." + _precision + "lf", res.c_str(), contrib);
-			}
+			res = Utils::sformat("%s " + _number_formatter, res.c_str(), contrib);
 		}
 
 		return res;

--- a/src/Observables/PotentialEnergy.cpp
+++ b/src/Observables/PotentialEnergy.cpp
@@ -32,20 +32,31 @@ void PotentialEnergy::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
 	getInputBool(&my_inp, "split", &_split, 0);
+	getInputString(&my_inp, "precision", _precision, 0);
 }
 
 std::string PotentialEnergy::get_output_string(llint curr_step) {
 	if(!_split) {
 		number energy = get_potential_energy();
 
-		return Utils::sformat("% 10.6lf", energy);
+		if (_precision == "") {
+			return Utils::sformat("% 10.6lf", energy);
+		}
+		else {
+			return Utils::sformat("% 10." + _precision + "lf", energy);
+		}
 	}
 	else {
 		std::string res("");
 		auto energies = _config_info->interaction->get_system_energy_split(_config_info->particles(), _config_info->lists);
 		for(auto energy_item : energies) {
 			number contrib = energy_item.second / _config_info->N();
-			res = Utils::sformat("%s % 10.6lf", res.c_str(), contrib);
+			if (_precision == "") {
+				res = Utils::sformat("%s % 10.6lf", res.c_str(), contrib);
+			}
+			else {
+				res = Utils::sformat("%s % 10." + _precision + "lf", res.c_str(), contrib);
+			}
 		}
 
 		return res;

--- a/src/Observables/PotentialEnergy.h
+++ b/src/Observables/PotentialEnergy.h
@@ -24,7 +24,6 @@
 class PotentialEnergy: public BaseObservable {
 protected:
 	bool _split;
-	std::string _precision;
 
 public:
 	PotentialEnergy();

--- a/src/Observables/PotentialEnergy.h
+++ b/src/Observables/PotentialEnergy.h
@@ -24,6 +24,8 @@
 class PotentialEnergy: public BaseObservable {
 protected:
 	bool _split;
+	std::string _precision;
+
 public:
 	PotentialEnergy();
 	virtual ~PotentialEnergy();


### PR DESCRIPTION
I had previously sent in a pull request where I had removed the %s from the split fmt, leading to a bug. All cases have been checked, this time, where each case has given me the intended behavior. Apologies for the confusion.

Motivation: the energy of an external force applied to a particle in an origami size system becomes 0.0 with the currently implemented precision when divided out by the number of particles, especially when you have multiple groups. Having the option to change the precision of Potential Energy obs is nice for when you split the contributions.