### PR TITLE
fix: removal of now removed 'center' keywords from align function call

### DIFF
--- a/analysis/src/oxDNA_analysis_tools/align.py
+++ b/analysis/src/oxDNA_analysis_tools/align.py
@@ -62,7 +62,7 @@ def compute(ctx:ComputeContext, chunk_size, chunk_id:int):
 
     # align
     for i, c in enumerate(np_coords):
-        c[0], c[1], c[2] = svd_align(ctx.centered_ref_coords, c, ctx.indexes, ref_center=np.zeros(3), center=ctx.center)
+        c[0], c[1], c[2] = svd_align(ctx.centered_ref_coords, c, ctx.indexes, ref_center=np.zeros(3))
         confs[i].positions = c[0]
         confs[i].a1s = c[1]
         confs[i].a3s = c[2]


### PR DESCRIPTION
8a6ed9d961c9a96983230bebb1dad231251567ba removed the unused keyword 'center' from svd_align
this removes the left-over call with the keyword 