### PR TITLE
fix(oxpy): bool_input lowercase fixes #138

### DIFF
--- a/oxpy/bindings_includes/input_file.h
+++ b/oxpy/bindings_includes/input_file.h
@@ -67,21 +67,9 @@ To check if a specific option has been set you can use `in`::
 	)pbdoc");
 
 	input.def("get_bool", [](input_file &inp, std::string &key) {
-		bool found;
-		std::string value = inp.get_value(key, 0, found);
-		std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-
-		if (inp.true_values.find(value) != inp.true_values.end()) {
-			return true;
-		}
-		else {
-			if (inp.false_values.find(value) != inp.false_values.end()) {
-				return false;
-			}
-			else {
-				throw std::invalid_argument("boolean key " + key + " is invalid");
-			}
-		}
+		bool res;
+		getInputBool(&inp, key.c_str(), &res, 0);
+		return res;
 	}, R"pbdoc(
 		Return the boolean value of an input option.
 

--- a/oxpy/bindings_includes/input_file.h
+++ b/oxpy/bindings_includes/input_file.h
@@ -68,11 +68,14 @@ To check if a specific option has been set you can use `in`::
 
 	input.def("get_bool", [](input_file &inp, std::string &key) {
 		bool found;
-		if (inp.true_values.find(inp.get_value(key, 0, found)) != inp.true_values.end()) {
+		std::string value = inp.get_value(key, 0, found);
+		std::transform(value.begin(), value.end(), value.begin(), ::tolower);
+
+		if (inp.true_values.find(value) != inp.true_values.end()) {
 			return true;
 		}
 		else {
-			if (inp.false_values.find(inp.get_value(key, 0, found)) != inp.false_values.end()){
+			if (inp.false_values.find(value) != inp.false_values.end()) {
 				return false;
 			}
 			else {


### PR DESCRIPTION
make all boolean input lowercase, enabling f.e. True, TRUE this is the behavior of the C++ code (compare parse_input.cpp:408 fixes unexpected error on uppercase bool in OAT scripts that us the binding get_bool

fixes #138