### PR TITLE
Fix for Minor Issues with PDB <--> OxDNA Conversion

### DIFF
--- a/analysis/src/oxDNA_analysis_tools/PDB_oxDNA.py
+++ b/analysis/src/oxDNA_analysis_tools/PDB_oxDNA.py
@@ -206,9 +206,12 @@ def PDB_oxDNA(pdb_str:str, old_top:bool=False) -> Tuple[List[Configuration], Lis
                 end_system()
             continue
     
-    # Catch the case where there was no TER or END identifier
+    # Catch the case where there was no TER identifier
     if len(strand) > 0: 
         end_strand()
+        
+    # Catch the case where there was no END identifier
+    if len(sys) > 0:
         end_system()
     
     return configs, systems

--- a/analysis/src/oxDNA_analysis_tools/oxDNA_PDB.py
+++ b/analysis/src/oxDNA_analysis_tools/oxDNA_PDB.py
@@ -283,7 +283,7 @@ def oxDNA_PDB(conf:Configuration, system:System, out_basename:str, protein_pdb_f
         atom_counter = 1
 
         # Iterate over strands in the oxDNA file
-        for strand in system.strands:
+        for i, strand in enumerate(system.strands):
             strand_pdb = []
             nucleotides_in_strand = strand.monomers
             sequence = [n.btype for n in nucleotides_in_strand]
@@ -381,11 +381,13 @@ def oxDNA_PDB(conf:Configuration, system:System, out_basename:str, protein_pdb_f
             # Either open a new file or increment chain ID
             # Chain ID can be any alphanumeric character.  Convention is A-Z, a-z, 0-9
             if one_file_per_strand:
+                print("END", file=out) # Add the END identifier
                 out.close()
                 log("Wrote strand {}'s data to {}".format (strand.id, out_name))
                 chain_id = 'A'
-                if strand != system.strands[-1]:
-                    out_name = out_basename + "_{}.pdb".format(strand.id, )
+                if i < len(system) - 1:
+                    next_strand = system.strands[i + 1]
+                    out_name = out_basename + "_{}.pdb".format(next_strand.id, )
                     out = open(out_name, "w")
             else:
                 chain_id = chr(ord(chain_id)+1)
@@ -396,6 +398,10 @@ def oxDNA_PDB(conf:Configuration, system:System, out_basename:str, protein_pdb_f
                 elif chain_id == chr(ord('0')+1):
                     log("More than 62 chains identified, looping chain identifier...", level='warning')
                     chain_id = 'A'
+        
+        # Add the END identifier at the end of the file
+        if not one_file_per_strand:
+            print("END", file=out)
         print()
 
     log("Wrote data to '{}'".format(out_name))


### PR DESCRIPTION
Hi, 

Thank you so much for integrating the full conversion feature for PDB <--> OxDNA in oat—it's fantastic!

I tested the conversion by converting some oxDNA files to PDB and back. While the conversion from oxDNA to PDB worked flawlessly, I encountered issues with the conversion from PDB to oxDNA, particularly for single strands. After investigating, I identified the following problems:

1. The conversion from oxDNA to PDB does not add the "END" identifier at the end of the PDB file.
2. When the `one_file_per_strand` flag is set to `True`, the oxDNA to PDB conversion saves each strand with the `strand.id` of the previous strand.
3. If the 'TER' identifier is present but the 'END' identifier is missing, the PDB to oxDNA conversion function does not include the last system in the output. For example, it doesn't add the last system in PDB files generated with oxDNA to PDB (which miss the 'END' identifier).

I have addressed all these issues with minor changes to the code.

Looking forward to your feedback!

Best,  
 Luca
