### PR TITLE
Fixed mutable default argument (strands list) in System

### DIFF
--- a/analysis/src/oxDNA_analysis_tools/UTILS/data_structures.py
+++ b/analysis/src/oxDNA_analysis_tools/UTILS/data_structures.py
@@ -99,8 +99,10 @@ class System:
     top_file: str
     strands: List[Strand]
 
-    def __init__(self, top_file:str='', strands:List[Strand] = []):
+    def __init__(self, top_file:str='', strands:List[Strand] = None):
         self.top_file = top_file
+        if strands is None:
+            strands = []
         self.strands = strands
 
     def __getitem__(self, key):


### PR DESCRIPTION
Hi everyone!
I ran into a small bug while converting PDB structures to oxDNA format. When calling PDB_oxDNA multiple times with the same input, the number of coordinates kept increasing unexpectedly:

```
from oxDNA_analysis_tools.PDB_oxDNA import PDB_oxDNA

# PDB file with 4 nucleotides
with open('aauu.pdb', 'r') as f: 
    pdb_text = f.read()

# First run – works fine
confs, systems = PDB_oxDNA(pdb_text)
print(len(confs[0].positions))  # >> 4

# Second run – coordinates accumulate
confs, systems = PDB_oxDNA(pdb_text)
print(len(confs[0].positions))  # >> 8

# Third run – keeps growing
confs, systems = PDB_oxDNA(pdb_text)
print(len(confs[0].positions))  # >> 12

```

After a bit of debugging, I noticed that the System object used a mutable default argument: `strands: List[Strand] = []`. This is one of those [classic Python gotchas](https://stackoverflow.com/questions/1132941/least-astonishment-and-the-mutable-default-argument), as the default argument is evaluated only once and then reused every time the System object is created, so the strands accumulate across calls.
I changed it to use the safer `None` default pattern, and now it works as expected.
Thank you for developing oxDNA and the analysis tools — they’re great!
Cheers,
Luca
