### PR TITLE
Update boilerplate exposing analysis and make Simulation class behave like dict 

### DIFF
--- a/analysis/src/oxDNA_analysis_tools/UTILS/boilerplate.py
+++ b/analysis/src/oxDNA_analysis_tools/UTILS/boilerplate.py
@@ -439,3 +439,9 @@ class Simulation(MutableMapping):
 
         # and the line indicating the complete run
         plt.plot([steps,steps],ylim, color="r")
+
+    @path_decorator
+    def get_log(self):
+        """default boilerplate sim output is stored in the log file"""
+        with open(self["log_file"]) as file:
+            return file.readlines()

--- a/analysis/src/oxDNA_analysis_tools/UTILS/boilerplate.py
+++ b/analysis/src/oxDNA_analysis_tools/UTILS/boilerplate.py
@@ -1,22 +1,25 @@
 import oxpy
 from os.path import join, abspath, dirname, exists, basename
-from os import mkdir, getpid,chdir, getcwd
+from os import mkdir,chdir, getcwd
 from multiprocessing import Process
 from shutil import copyfile, rmtree
-from oxDNA_analysis_tools.UTILS.oxview import from_path, oxdna_conf
+from oxDNA_analysis_tools.UTILS.oxview import oxdna_conf
 from json import dumps
 import matplotlib.pyplot as plt
-import pandas as pd
 from copy import deepcopy
-import sys
-from oxDNA_analysis_tools.UTILS.RyeReader import describe, get_confs
+from oxDNA_analysis_tools.UTILS.RyeReader import describe, get_confs,write_conf
 import ipywidgets as widgets
 from IPython.display import display, IFrame
 import numpy as np
 from functools import wraps
-import subprocess
 from typing import List, Union, Dict
 import contextlib 
+from collections.abc import MutableMapping
+#oat analysis
+from oxDNA_analysis_tools.mean import mean
+from oxDNA_analysis_tools.deviations import deviations
+from oxDNA_analysis_tools.align import align
+
 
 default_input_file = {
     "T" :"20C",
@@ -47,6 +50,8 @@ default_input_file = {
 }
 
 
+class SimulationRunningError(Exception):
+    pass #used to indicate we have a running simulation
 
 
 class PathContext(contextlib.ContextDecorator):
@@ -139,10 +144,13 @@ def setup_simulation(top_path:str, dat_path:str, out_dir:str, parameters:Dict[st
         input_file["external_forces_file"] = "forces.json"
     
     
-    # set all base simulation parameters, overriding previous
-    for k,v in parameters.items():
-        input_file[k]=str(v)
-    
+    # stuff wich was already set triggers logging, 
+    # so we need to provide it 
+    with oxpy.Context():
+        # set all base simulation parameters, overriding previous
+        for k,v in parameters.items():
+            input_file[k]=str(v)
+        
     
     #prevents output
     input_file["log_file"] = "logfile"
@@ -164,26 +172,52 @@ def _prun(input_file_path:str):
             manager.run_complete() #run complete run's it till the number steps specified are reached 
             
 
-class Simulation:
+class Simulation(MutableMapping):
     def __init__(self, input_file_path:str):
         """
             creates a simulation object from the given input file path
 
             input_file_path (str): path to the input file
         """
-        self.input_file = oxpy.InputFile()
-        self.input_file.init_from_filename(input_file_path)
+        self._input_file = oxpy.InputFile()
+        self._input_file.init_from_filename(input_file_path)
         self.p = None # the process refference
         self.out_dir = dirname(abspath(input_file_path))
         self.__input_file_path = input_file_path
+
+
+    # We support full dictionary like behavior on the Simulation class hiding the InputFile object (MutableMapping inheretance)
+    def __setitem__(self, key, value):
+        """
+            provides a way to modify input file object parameters,
+            s = Simulation("./input")
+            s["conf_file"] = "./new_name" 
+        """
+        with oxpy.Context():
+            self._input_file[key] = value
+
+    def __getitem__(self, key):
+        """ handles the retrival of input file parameters """
+        return self._input_file[key]
     
+    def __delitem__(self, key):
+        with oxpy.Context():
+            del self._data[key]
+
+    def __iter__(self):
+        return (key for key in self._input_file.keys()) 
+
+    def __len__(self):
+        return len(self._input_file.keys())
+    #************************************************************************************************
+     
     @path_decorator
     def get_init_conf(self):
         """
             returns the initial configuration of the simulation as a rye reader object
         """
-        ti, di = describe(abspath(self.input_file["topology"]),
-                          abspath(self.input_file["conf_file"]))
+        ti, di = describe(abspath(self["topology"]),
+                          abspath(self["conf_file"]))
         return (ti, di), get_confs(ti, di, 0, 1)[0]
     
     @path_decorator
@@ -191,38 +225,17 @@ class Simulation:
         """
             returns the last configuration of the simulation as a rye reader object
         """
-        ti, di = describe(abspath(self.input_file["topology"]),
-                          abspath(self.input_file["lastconf_file"]))
+        ti, di = describe(abspath(self["topology"]),
+                          abspath(self["lastconf_file"]))
         return (ti,di), get_confs(ti, di, 0,1)[0]
-        
-    
-    def view_init(self, inbox_settings:List[str] = ["Monomer", "Origin"], height:int = 500):
-        """
-            opens the initial configuration in an embeded oxDNA viewer window
-
-            inbox_settings (List[str]): a list of strings, the inbox settings to use
-            height (int): height of the view
-        """
-        (ti,di), conf = self.get_init_conf()        
-        oxdna_conf(ti, conf, inbox_settings=inbox_settings, height=height)
-                          
-    def view_last(self, inbox_settings:List[str] = ["Monomer", "Origin"], height:int = 500):
-        """
-            opens the last configuration in an embeded oxDNA viewer window
-
-            inbox_settings (List[str]): a list of strings, the inbox settings to use
-            height (int): height of the view
-        """
-        (ti,di), conf = self.get_last_conf()
-        oxdna_conf(ti, conf, inbox_settings=inbox_settings, height=height)
-    
+                             
     @path_decorator
     def get_conf_count(self):
         """
             returns the number of configurations in the trajectory
         """
-        ti,di = describe(abspath(self.input_file["topology"]),
-                         abspath(self.input_file["trajectory_file"]))
+        ti,di = describe(abspath(self["topology"]),
+                         abspath(self["trajectory_file"]))
         return len(di.idxs)
     
     @path_decorator
@@ -231,15 +244,42 @@ class Simulation:
             returns the configuration at the given index in the trajectory
             as a rye reader object
         """
-        ti,di = describe(abspath(self.input_file["topology"]),
-                         abspath(self.input_file["trajectory_file"]))
+        ti,di = self.get_trajectory_handle()
+
         l = len(di.idxs)
         if(id < l):
             return (ti,di), get_confs(ti,di, id, 1)[0]
         else:
             raise Exception("You requested a conf out of bounds.")
+    
+    @path_decorator
+    def get_trajectory_handle(self):
+        "usefull for processing stuff"
+        ti,di = describe(abspath(self["topology"]),
+                         abspath(self["trajectory_file"]))
+        return ti,di
 
-    def view_conf(self, id:int, inbox_settings:List[str] =  ["Monomer", "Origin"], height:int = 500):
+    def view_init(self, overlay:Dict[str,List] = None, script_file_path:str = None, inbox_settings:List[str] = ["Monomer", "Origin"], height:int = 500):
+        """
+            opens the initial configuration in an embeded oxDNA viewer window
+
+            inbox_settings (List[str]): a list of strings, the inbox settings to use
+            height (int): height of the view
+        """
+        (ti,di), conf = self.get_init_conf()        
+        oxdna_conf(ti, conf, overlay=overlay, script_file_path = script_file_path, inbox_settings=inbox_settings, height=height)
+
+    def view_last(self, overlay:Dict[str,List] = None, script_file_path:str = None,inbox_settings:List[str] = ["Monomer", "Origin"], height:int = 500):
+        """
+            opens the last configuration in an embeded oxDNA viewer window
+
+            inbox_settings (List[str]): a list of strings, the inbox settings to use
+            height (int): height of the view
+        """
+        (ti,di), conf = self.get_last_conf()
+        oxdna_conf(ti, conf, inbox_settings=inbox_settings, height=height, overlay=overlay,script_file_path = script_file_path)
+ 
+    def view_conf(self, id:int, overlay:Dict[str,List] = None, script_file_path:str = None, inbox_settings:List[str] =  ["Monomer", "Origin"], height:int = 500):
         """ 
             opens the configuration at the given index in the trajectory as an embeded oxDNA viewer window
 
@@ -247,10 +287,9 @@ class Simulation:
             height (int): height of the view
         """
         (ti,di), conf = self.get_conf(id)
-        oxdna_conf(ti, conf, inbox_settings=inbox_settings, height=height)
+        oxdna_conf(ti, conf, inbox_settings=inbox_settings, height=height,overlay=overlay,script_file_path=script_file_path)
     
-
-    def view_traj(self,  init:int = 0, op=None, inbox_settings:List[str] = ["Monomer", "Origin"], height:int = 500):
+    def view_traj(self, init:int = 0, overlay:Dict[str,List] = None, script_file_path:str = None, op=None, inbox_settings:List[str] = ["Monomer", "Origin"], height:int = 500):
         """
             opens the trajectory in an embeded oxDNA viewer window
 
@@ -286,13 +325,12 @@ class Simulation:
                     print(init)
                     plt.plot([slider.value,slider.value],[min_v, max_v], color="r")
                     plt.show()
-                oxdna_conf(ti,conf, inbox_settings=inbox_settings, height=height)
+                oxdna_conf(ti,conf, inbox_settings=inbox_settings, height=height, overlay=overlay, script_file_path=script_file_path)
                 
         slider.observe(handle)
         display(slider,output)
         handle(None)       
-     
-    
+        
     def is_alive(self):
         """
             returns true if the simulation is still running
@@ -301,57 +339,6 @@ class Simulation:
             print(self.p.is_alive())
         else:
             print(False)
-    
-    def run(self):
-        """
-            runs the simulation
-        """
-
-        # if we have any reference to a simulation
-        if(self.p):
-            self.terminate()
-        
-        #spawn the process
-        self.p = Process(target=_prun, args = (self.__input_file_path,))
-        
-        self.p.start()
-        return self
-       
-    @path_decorator
-    def plot_energy(self, ylim = [-2,0]):
-        """
-            plots the energy graph of the running simulation
-        """
-        if self.input_file["sim_type"] == "MD":
-            df = pd.read_csv(self.input_file["energy_file"], delimiter="\s+",names=['time', 'U','P','K'])
-            dt = float(self.input_file["dt"])
-            steps = float(self.input_file["steps"])
-
-            # make sure our figure is bigger
-            plt.figure(figsize=(15,3)) 
-            # plot the energy
-            plt.plot(df.time/dt,df.U)
-
-            plt.ylabel("Energy")
-            plt.xlabel("Steps")
-            # and the line indicating the complete run
-            plt.ylim(ylim)
-            plt.plot([steps,steps],ylim, color="r")
-        else:
-            # assume we have MC
-            df = pd.read_csv(self.input_file["energy_file"], delimiter="\s+",names=['time', 'U','accept_translaitons','accept_rotations', 'smth'])
-            steps = float(self.input_file["steps"])
-
-            # make sure our figure is bigger
-            plt.figure(figsize=(15,3)) 
-            # plot the energy
-            plt.plot(df.time,df.U)
-
-            plt.ylabel("Energy")
-            plt.xlabel("Steps")
-            # and the line indicating the complete run
-            plt.ylim(ylim)
-            plt.plot([steps,steps],ylim, color="r")
 
     def terminate(self):
         """
@@ -360,3 +347,95 @@ class Simulation:
         if(self.p):
             self.p.terminate()
             print("you evil...")
+
+    def run(self):
+        """
+            runs the simulation
+        """
+
+        # if we have any reference to a simulation
+        if(self.p):
+            self.terminate()
+
+
+        #make sure we pick up new settings if anything was changed
+        with open(self.__input_file_path,"w") as file:
+            file.write(str(self._input_file))
+        
+        #spawn the process
+        self.p = Process(target=_prun, args = (self.__input_file_path,))
+        self.p.start()
+        return self
+    
+    @path_decorator 
+    def compute_mean(self,ref_conf = None, indixes = None, ncpus=1):
+        """returns ti,di of computed mean structure"""
+        ti,di = self.get_trajectory_handle()
+        # Compute the mean structure and RMSFs
+        mean_conf = mean(di, ti, ref_conf, indixes, ncpus)
+        write_conf("./mean.dat", mean_conf, False, False)
+        #now we get it's handle 
+        ti,di = describe(self["topology"], "./mean.dat")
+        return (ti,di), mean_conf
+    
+    @path_decorator
+    def compute_align(self, ref_conf = None, indixes = None, center=True, ncpus=1):
+        align(self["trajectory_file"], "./aligned.dat", ncpus, indixes, ref_conf, center)
+        # handle to the aligned traj
+        ti,di = describe(self["topology"], "./aligned.dat")
+        return (ti, di), "./aligned.dat"
+    
+    @path_decorator
+    def compute_deviations(self, ref_conf = None,  indixes = None, ncpus=1):
+        ti,di = self.get_trajectory_handle()
+        RMSDs, RMSFs = deviations(di, ti, ref_conf, indixes,  ncpus)
+        # #They come out as numpy arrays, need to be a dict with a list for visualization
+        RMSFs = {"RMSF": RMSFs.tolist()}
+        return RMSDs, RMSFs
+
+    @path_decorator
+    def plot_energy(self, ylim = [-2,0]):
+        """
+            plots the energy graph of the running simulation
+        """
+        if not exists(self["energy_file"]):
+            print("No energy file yet.")
+            return
+        
+        data = np.loadtxt(self["energy_file"])
+
+        # make sure our figure is bigger and make it pretty
+        plt.figure(figsize=(15,3)) 
+        plt.ylabel("Energy")
+        plt.xlabel("Steps")
+        plt.ylim(ylim)
+        
+        if self._input_file["sim_type"] == "MD":
+            dt = float(self["dt"])
+            steps = float(self["steps"])
+            data = np.loadtxt(self["energy_file"])
+            #used to be a df, now we use only numpy
+            df = {'time': data[:, 0], 
+                  'U': data[:, 1], 
+                  #'P': data[:, 2], 
+                  #'K': data[:, 3]
+            }
+
+            # plot the energy
+            plt.plot(df["time"]/dt,
+                     df["U"])
+        else:
+            # assume we have MC
+            df = {
+                'time': data[:, 0],
+                'U': data[:, 1],
+                #'accept_translations': data[:, 2],
+                #'accept_rotations': data[:, 3],
+                #'smth': data[:, 4]
+            }
+            steps = float(self["steps"])
+            # plot the energy
+            plt.plot(df["time"],df["U"])
+
+        # and the line indicating the complete run
+        plt.plot([steps,steps],ylim, color="r")

--- a/analysis/src/oxDNA_analysis_tools/UTILS/oxview.py
+++ b/analysis/src/oxDNA_analysis_tools/UTILS/oxview.py
@@ -2,7 +2,7 @@ from oxDNA_analysis_tools.UTILS.RyeReader import Configuration, TopInfo
 from IPython.display import display, HTML
 from random import randint
 from json import dumps
-from typing import List, Union
+from typing import List, Union,Dict
     
 def __compress_dat(conf):
     """ generate me a compressed double escaped dat file """
@@ -103,14 +103,14 @@ def from_path(*args:Union[List[str],List[List[str]]] , **kwargs):
     
     
     
-def oxdna_conf(top: TopInfo, conf:Configuration, overlay:str = None, forces_path:str = None, par_file_path:str = None , script_file_path:str = None, inbox_settings:List[str] = ["Monomer", "Origin"], oxview_src:str = "https://sulcgroup.github.io/oxdna-viewer/", height:int = 500):
+def oxdna_conf(top: TopInfo, conf:Configuration, overlay:Dict[str,List] = None, forces_path:str = None, par_file_path:str = None , script_file_path:str = None, inbox_settings:List[str] = ["Monomer", "Origin"], oxview_src:str = "https://sulcgroup.github.io/oxdna-viewer/", height:int = 500):
     """
         Display an oxDNA configuration in oxview
 
         Parameters:
             top (TopInfo) : the top file data
             conf (Configuration) : the configuration data
-            overlay (str) : (optional) the path to the overlay file
+            overlay Dict[str:List] : (optional) dictionary with the color overlay
             forces_path (str) : (optional) the path to the forces file
             par_file_path (str) : (optional) the path to the par file
             script_file_path (str) : (optional) the path to the script file (js)


### PR DESCRIPTION
* make Simulation a dictionary of InputFile keys, 
* improvements to view_functions 
* expose analysis 
Example:
```
from oxDNA_analysis_tools.UTILS.boilerplate import get_default_input, Simulation, setup_simulation
import oxpy

input = get_default_input()
s = Simulation(setup_simulation("hairpin.top", "hairpin.conf", "./out2/", input, kill_out_dir="True"))
s.run()
s.p.join()

_, mean =  s.compute_mean()
_, aligned_path = s.compute_align()

# we switch out the trajectory, cause deviations get computed from s["trajectory_file"]
s["trajectory_file"] =  aligned_path
_, rmsf = s.compute_deviations(mean)

# view trajectory with overlay
s.view_traj(overlay=rmsf)

```
