### PR TITLE
Fixed error messages from Sphinx in doc generation

### DIFF
--- a/analysis/src/oxDNA_analysis_tools/UTILS/data_structures.py
+++ b/analysis/src/oxDNA_analysis_tools/UTILS/data_structures.py
@@ -86,16 +86,18 @@ class TopInfo:
 
 class System:
     """
-        Object hierarchy representation of an oxDNA configuration
+    Object hierarchy representation of an oxDNA configuration
 
-        Can be accessed and modified using Python list syntax (implements __getitem__, __setitem__, and __iter__) for accessing Strand objects.
+    Can be accessed and modified using Python list syntax (implements __getitem__, __setitem__, and __iter__) for accessing Strand objects.
 
-        Parameters:
-            top_file (str) : The path to the topology file creating the system
-            strands (List[Strand]) : A list of Strand objects
+    Parameters:
+        top_file (str) : The path to the topology file creating the system
+        strands (List[Strand]) : A list of Strand objects
     """
 
+    #: The path to the topology file creating the system
     top_file: str
+    #: List of constituent Strand objects
     strands: List[Strand]
 
     def __init__(self, top_file:str='', strands:Union[List[Strand],None]=None):
@@ -115,38 +117,36 @@ class System:
 
     def append(self, strand:Strand):
         """
-            Append a strand to the system.
+        Append a strand to the system.
 
-            Modifies this system in-place.
+        Modifies this system in-place.
 
-            Parameters:
-                strand (Strand) : The strand to append
+        Parameters:
+            strand (Strand) : The strand to append
         """
         self.strands.append(strand)
 
 class Strand:
     """
-        Object hierarchy representation of an oxDNA strand.
+    Object hierarchy representation of an oxDNA strand.
 
-        Can be accessed and modified using Python list syntax (implements __getitem__, __setitem__, and __iter__) for accessing Monomer objects.
+    Can be accessed and modified using Python list syntax (implements __getitem__, __setitem__, and __iter__) for accessing Monomer objects.
 
-        Parameters:
-            id (int) : The id of the strand
-            *initial_data (list[dict]) : Set additional attributes of the strand object (currently unused)
-            **kwargs (dict) : Set addtional attributes of the strand object from key:value pairs.
-
-        Attributes:
-            _from_old (bool) : Was this created from an old-style topology file? (default : False)
-            id (int) : ID of this strand in the topology file
-            monomers (list[Monomer]) : List of consitutent monomer objects (default : [])
-            type (str) : Type of molecule this represents (default : DNA)
-            circular (bool) : Is this a circular strand? (default : False)
+    Parameters:
+        id (int) : The id of the strand
+        *initial_data (list[dict]) : Set additional attributes of the strand object (currently unused)
+        **kwargs (dict) : Set additional attributes of the strand object from key:value pairs.
     """
-
+    
+    #: Was this created from an old-style topology file? (default: False)
     _from_old: bool
+    #: ID of this strand in the topology file
     id: int
+    #: List of constituent monomer objects (default [])
     monomers: List[Monomer]
+    #: Type of molecule this represents (default DNA)
     type: str
+    #: Is this a circular strand? (default False)
     circular: bool
 
     def __init__(self, id, *initial_data, **kwargs):

--- a/analysis/src/oxDNA_analysis_tools/oxDNA_PDB.py
+++ b/analysis/src/oxDNA_analysis_tools/oxDNA_PDB.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import inspect
 import numpy as np
 import copy
 import argparse
@@ -16,7 +17,8 @@ from oxDNA_analysis_tools.UTILS.data_structures import Strand, Configuration, Sy
 from oxDNA_analysis_tools.UTILS.logger import log, logger_settings
 import oxDNA_analysis_tools.UTILS.utils as utils
 
-PDB_PATH = Path(os.path.dirname(__file__)+"/UTILS/pdb_templates/")
+# This is terrible code, but it *does* get the path of this file whether its run as a script or imported as a module or whatever Sphinx does to build docs.
+PDB_PATH = Path(os.path.dirname(os.path.realpath(inspect.getfile(inspect.currentframe())))+"/UTILS/pdb_templates/")
 
 number_to_DNAbase = {0 : 'A', 1 : 'G', 2 : 'C', 3 : 'T'}
 number_to_RNAbase = {0 : 'A', 1 : 'G', 2 : 'C', 3 : 'U'}
@@ -91,7 +93,7 @@ def choose_reference_nucleotides(nucleotides:List[PDB_Nucleotide]) -> Dict[str, 
     """
         Find nucleotides that most look like an oxDNA nucleotide (orthogonal a1 and a3 vectors).
 
-        This function is never used in any production code, but it is used in development code to build the reference library.
+        This function is never used in any production code, but it is used for building the reference library by `development code <https://github.com/ErikPoppleton/oxDNA_backmapping>`_. 
 
         Parameters:
             nucleotides (List[PDB_Nucleotide]) : List of nucleotides to compare.
@@ -233,7 +235,7 @@ def write_strand_to_PDB(strand_pdb:List[Dict], chain_id:str, atom_counter:int, o
 
 def oxDNA_PDB(conf:Configuration, system:System, out_basename:str, protein_pdb_files:Union[List[str], None]=None, reverse:bool=False, hydrogen:bool=True, uniform_residue_names:bool=False, one_file_per_strand:bool=False, rmsf_file:str=''):
     """
-        Convert an oxDNA file to a PDB file.  Directly writes the file.
+        Convert an oxDNA file to a PDB file using fragment assembly.  Directly writes the file.
 
         Parameters:
             conf (Configuration) : The Configuration to convert

--- a/docs/source/oat/api.md
+++ b/docs/source/oat/api.md
@@ -30,8 +30,8 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.align.align
-    oxDNA_analysis_tools.align.svd_align
+    align.align
+    align.svd_align
     
 .. autofunction:: oxDNA_analysis_tools.align.align
 .. autofunction:: oxDNA_analysis_tools.align.svd_align
@@ -48,7 +48,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.anm_parameterize.anm_parameterize
+    anm_parameterize.anm_parameterize
     
 .. autofunction:: oxDNA_analysis_tools.anm_parameterize.anm_parameterize
 ```
@@ -64,7 +64,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.backbone_flexibility.backbone_flexibility
+    backbone_flexibility.backbone_flexibility
     
 .. autofunction:: oxDNA_analysis_tools.backbone_flexibility.backbone_flexibility
 ```
@@ -80,7 +80,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.bond_analysis.bond_analysis
+    bond_analysis.bond_analysis
     
 .. autofunction:: oxDNA_analysis_tools.bond_analysis.bond_analysis
 ```
@@ -96,7 +96,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.centroid.centroid
+    centroid.centroid
     
 .. autofunction:: oxDNA_analysis_tools.centroid.centroid
 ```
@@ -112,9 +112,9 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.clustering.split_trajectory
-    oxDNA_analysis_tools.clustering.get_centroid
-    oxDNA_analysis_tools.clustering.perform_DBSCAN
+    clustering.split_trajectory
+    clustering.get_centroid
+    clustering.perform_DBSCAN
     
 .. autofunction:: oxDNA_analysis_tools.clustering.split_trajectory
 .. autofunction:: oxDNA_analysis_tools.clustering.get_centroid
@@ -132,9 +132,9 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.config.check
-    oxDNA_analysis_tools.config.set_chunk_size
-    oxDNA_analysis_tools.config.get_chunk_size
+    config.check
+    config.set_chunk_size
+    config.get_chunk_size
     
 .. autofunction:: oxDNA_analysis_tools.config.check
 .. autofunction:: oxDNA_analysis_tools.config.set_chunk_size
@@ -152,7 +152,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.contact_map.contact_map
+contact_map.contact_map
     
 .. autofunction:: oxDNA_analysis_tools.contact_map.contact_map
 ```
@@ -168,7 +168,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.decimate.decimate
+decimate.decimate
     
 .. autofunction:: oxDNA_analysis_tools.decimate.decimate
 ```
@@ -184,8 +184,8 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.deviations.deviations
-    oxDNA_analysis_tools.deviations.output
+deviations.deviations
+deviations.output
     
 .. autofunction:: oxDNA_analysis_tools.deviations.deviations
 .. autofunction:: oxDNA_analysis_tools.deviations.output
@@ -202,9 +202,9 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.distance.min_image
-    oxDNA_analysis_tools.distance.vectorized_min_image
-    oxDNA_analysis_tools.distance.distance
+distance.min_image
+distance.vectorized_min_image
+distance.distance
     
 .. autofunction:: oxDNA_analysis_tools.distance.min_image
 .. autofunction:: oxDNA_analysis_tools.distance.vectorized_min_image
@@ -222,11 +222,11 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.db_to_force.parse_dot_bracket
-    oxDNA_analysis_tools.db_to_force.db_to_forcelist
+db2forces.parse_dot_bracket
+db2forces.db_to_forcelist
     
-.. autofunction:: oxDNA_analysis_tools.db_to_force.parse_dot_bracket
-.. autofunction:: oxDNA_analysis_tools.db_to_force.db_to_forcelist
+.. autofunction:: oxDNA_analysis_tools.db2forces.parse_dot_bracket
+.. autofunction:: oxDNA_analysis_tools.db2forces.db_to_forcelist
 ```
 
 ## Duplex angle plotter
@@ -240,7 +240,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.duplex_angle_plotter.get_angle_between
+duplex_angle_plotter.get_angle_between
     
 .. autofunction:: oxDNA_analysis_tools.duplex_angle_plotter.get_angle_between
 ```
@@ -256,9 +256,9 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.duplex_finder.Duplex
-    oxDNA_analysis_tools.duplex_finder.find_duplex
-    oxDNA_analysis_tools.duplex_finder.duplex_finder
+duplex_finder.Duplex
+duplex_finder.find_duplex
+duplex_finder.duplex_finder
     
 .. autoclass:: oxDNA_analysis_tools.duplex_finder.Duplex
 .. autofunction:: oxDNA_analysis_tools.duplex_finder.find_duplex
@@ -276,7 +276,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.file_info.file_info
+file_info.file_info
     
 .. autofunction:: oxDNA_analysis_tools.file_info.file_info
 ```
@@ -292,7 +292,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.forces2db.forces2db
+forces2db.forces2db
     
 .. autofunction:: oxDNA_analysis_tools.forces2db.forces2db
 ```
@@ -308,7 +308,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.mean.mean
+mean.mean
     
 .. autofunction:: oxDNA_analysis_tools.mean.mean
 ```
@@ -324,7 +324,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.minify.minify
+minify.minify
     
 .. autofunction:: oxDNA_analysis_tools.minify.minify
 ```
@@ -340,8 +340,8 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.multidimensional_scaling_mean.multidimensional_scaling_mean
-    oxDNA_analysis_tools.multidimensional_scaling_mean.distance_deviations
+multidimensional_scaling_mean.multidimensional_scaling_mean
+multidimensional_scaling_mean.distance_deviations
     
 .. autofunction:: oxDNA_analysis_tools.multidimensional_scaling_mean.multidimensional_scaling_mean
 .. autofunction:: oxDNA_analysis_tools.multidimensional_scaling_mean.distance_deviations
@@ -358,7 +358,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.output_bonds.output_bonds
+output_bonds.output_bonds
     
 .. autofunction:: oxDNA_analysis_tools.output_bonds.output_bonds
 ```
@@ -374,9 +374,11 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.oxDNA_PDB.oxDNA_PDB
+oxDNA_PDB.oxDNA_PDB
+oxDNA_PDB.choose_reference_nucleotides
     
 .. autofunction:: oxDNA_analysis_tools.oxDNA_PDB.oxDNA_PDB
+.. autofunction:: oxDNA_analysis_tools.oxDNA_PDB.choose_reference_nucleotides
 ```
 
 ## Pairs to dot-bracket
@@ -390,7 +392,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.pairs2db.pairs2db
+pairs2db.pairs2db
     
 .. autofunction:: oxDNA_analysis_tools.pairs2db.pairs2db
 ```
@@ -405,7 +407,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.PDB_oxDNA.PDB_oxDNA
+PDB_oxDNA.PDB_oxDNA
     
 .. autofunction:: oxDNA_analysis_tools.PDB_oxDNA.PDB_oxDNA
 ```
@@ -421,9 +423,9 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.persistence_length.persistence_length
-    oxDNA_analysis_tools.persistence_length.get_r
-    oxDNA_analysis_tools.persistence_length.fit_PL
+persistence_length.persistence_length
+persistence_length.get_r
+persistence_length.fit_PL
     
 .. autofunction:: oxDNA_analysis_tools.persistence_length.persistence_length
 .. autofunction:: oxDNA_analysis_tools.persistence_length.get_r
@@ -441,10 +443,10 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.pca.align_positions
-    oxDNA_analysis_tools.pca.map_confs_to_pcs
-    oxDNA_analysis_tools.pca.make_heatmap
-    oxDNA_analysis_tools.pca.pca
+pca.align_positions
+pca.map_confs_to_pcs
+pca.make_heatmap
+pca.pca
     
 .. autofunction:: oxDNA_analysis_tools.pca.align_positions
 .. autofunction:: oxDNA_analysis_tools.pca.map_confs_to_pcs
@@ -463,7 +465,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.subset_trajectory.subset
+subset_trajectory.subset
     
 .. autofunction:: oxDNA_analysis_tools.subset_trajectory.subset
 ```
@@ -479,7 +481,7 @@ decimate(align_output, decimate_output, ncpus=5, start=200, stride=10)
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.superimpose.superimpose
+superimpose.superimpose
     
 .. autofunction:: oxDNA_analysis_tools.superimpose.superimpose
 ```

--- a/docs/source/oat/forces.md
+++ b/docs/source/oat/forces.md
@@ -12,13 +12,13 @@ Python data structures for all forces defined by oxDNA
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.external_force_utils.forces.mutual_trap
-    oxDNA_analysis_tools.external_force_utils.forces.string
-    oxDNA_analysis_tools.external_force_utils.forces.harmonic_trap
-    oxDNA_analysis_tools.external_force_utils.forces.rotating_harmonic_trap
-    oxDNA_analysis_tools.external_force_utils.forces.repulsion_plane
-    oxDNA_analysis_tools.external_force_utils.forces.attraction_plane
-    oxDNA_analysis_tools.external_force_utils.forces.repulsion_sphere
+    external_force_utils.forces.mutual_trap
+    external_force_utils.forces.string
+    external_force_utils.forces.harmonic_trap
+    external_force_utils.forces.rotating_harmonic_trap
+    external_force_utils.forces.repulsion_plane
+    external_force_utils.forces.attraction_plane
+    external_force_utils.forces.repulsion_sphere
 
 .. autofunction:: oxDNA_analysis_tools.external_force_utils.forces.mutual_trap
 .. autofunction:: oxDNA_analysis_tools.external_force_utils.forces.string
@@ -41,8 +41,8 @@ Read and write oxDNA external force files
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.external_force_utils.force_reader.read_force_file
-    oxDNA_analysis_tools.external_force_utils.force_reader.write_force_file
+    external_force_utils.force_reader.read_force_file
+    external_force_utils.force_reader.write_force_file
 
 .. autofunction:: oxDNA_analysis_tools.external_force_utils.force_reader.read_force_file
 .. autofunction:: oxDNA_analysis_tools.external_force_utils.force_reader.write_force_file

--- a/docs/source/oat/utils.md
+++ b/docs/source/oat/utils.md
@@ -11,14 +11,14 @@
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.UTILS.data_structures.Chunk
-    oxDNA_analysis_tools.UTILS.data_structures.ConfInfo
-    oxDNA_analysis_tools.UTILS.data_structures.TrajInfo
-    oxDNA_analysis_tools.UTILS.data_structures.Configuration
-    oxDNA_analysis_tools.UTILS.data_structures.TopInfo
-    oxDNA_analysis_tools.UTILS.data_structures.System
-    oxDNA_analysis_tools.UTILS.data_structures.Strand
-    oxDNA_analysis_tools.UTILS.data_structures.Monomer
+    UTILS.data_structures.Chunk
+    UTILS.data_structures.ConfInfo
+    UTILS.data_structures.TrajInfo
+    UTILS.data_structures.Configuration
+    UTILS.data_structures.TopInfo
+    UTILS.data_structures.System
+    UTILS.data_structures.Strand 
+    UTILS.data_structures.Monomer
     
 .. autoclass:: oxDNA_analysis_tools.UTILS.data_structures.Chunk
 .. autoclass:: oxDNA_analysis_tools.UTILS.data_structures.ConfInfo
@@ -42,9 +42,9 @@
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.UTILS.geom.fit_plane
-    oxDNA_analysis_tools.UTILS.geom.get_RNA_axis
-    oxDNA_analysis_tools.UTILS.geom.get_DNA_axis
+    UTILS.geom.fit_plane
+    UTILS.geom.get_RNA_axis
+    UTILS.geom.get_DNA_axis
 
 .. autofunction:: oxDNA_analysis_tools.UTILS.geom.fit_plane
 .. autofunction:: oxDNA_analysis_tools.UTILS.geom.get_RNA_axis
@@ -62,11 +62,11 @@
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.UTILS.oxview.display_files
-    oxDNA_analysis_tools.UTILS.oxview.from_path
-    oxDNA_analysis_tools.UTILS.oxview.oxdna_conf
-    oxDNA_analysis_tools.UTILS.oxview.loro_patchy_conf
-    oxDNA_analysis_tools.UTILS.oxview.flro_patchy_conf
+    UTILS.oxview.display_files
+    UTILS.oxview.from_path
+    UTILS.oxview.oxdna_conf
+    UTILS.oxview.loro_patchy_conf
+    UTILS.oxview.flro_patchy_conf
 
 .. autofunction:: oxDNA_analysis_tools.UTILS.oxview.display_files
 .. autofunction:: oxDNA_analysis_tools.UTILS.oxview.from_path
@@ -86,7 +86,7 @@
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.UTILS.oat_multiprocesser.oat_multiprocesser
+    UTILS.oat_multiprocesser.oat_multiprocesser
 
 .. autofunction:: oxDNA_analysis_tools.UTILS.oat_multiprocesser.oat_multiprocesser
 ```
@@ -102,19 +102,19 @@
 .. autosummary::
     :nosignatures:
 
-    oxDNA_analysis_tools.UTILS.RyeReader.Chunker
-    oxDNA_analysis_tools.UTILS.RyeReader.linear_read
-    oxDNA_analysis_tools.UTILS.RyeReader.get_confs
-    oxDNA_analysis_tools.UTILS.RyeReader.get_top_info
-    oxDNA_analysis_tools.UTILS.RyeReader.get_top_info_from_traj
-    oxDNA_analysis_tools.UTILS.RyeReader.get_traj_info
-    oxDNA_analysis_tools.UTILS.RyeReader.describe
-    oxDNA_analysis_tools.UTILS.RyeReader.strand_describe
-    oxDNA_analysis_tools.UTILS.RyeReader.get_input_parameter
-    oxDNA_analysis_tools.UTILS.RyeReader.inbox
-    oxDNA_analysis_tools.UTILS.RyeReader.write_conf
-    oxDNA_analysis_tools.UTILS.RyeReader.conf_to_str
-    oxDNA_analysis_tools.UTILS.RyeReader.get_top_string
+    UTILS.RyeReader.Chunker
+    UTILS.RyeReader.linear_read
+    UTILS.RyeReader.get_confs
+    UTILS.RyeReader.get_top_info
+    UTILS.RyeReader.get_top_info_from_traj
+    UTILS.RyeReader.get_traj_info
+    UTILS.RyeReader.describe
+    UTILS.RyeReader.strand_describe
+    UTILS.RyeReader.get_input_parameter
+    UTILS.RyeReader.inbox
+    UTILS.RyeReader.write_conf
+    UTILS.RyeReader.conf_to_str
+    UTILS.RyeReader.get_top_string
 
 .. autofunction:: oxDNA_analysis_tools.UTILS.RyeReader.Chunker
 .. autofunction:: oxDNA_analysis_tools.UTILS.RyeReader.linear_read


### PR DESCRIPTION
I just updated my local copy of Sphinx and when I tried to build the documentation I got a ton of import warnings from the OAT docs with a suggested fix.  I remedied all the warnings and added a few new docstrings, but before pushing to main I just want to double check that the documentation builds on others' systems.