### PR TITLE
Make it possible for external forces to also generate torques

### DIFF
--- a/contrib/rovigatti/src/Interactions/old/CUDALevyInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/old/CUDALevyInteraction.cu
@@ -125,7 +125,7 @@ __global__ void Levy_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0.f, 0.f, 0.f, 0.f);
+	c_number4 T = torques[IND];
 	c_number4 a1, a2, a3, b1, b2, b3;
 	get_vectors_from_quat(orientations[IND], a1, a2, a3);
 	c_number4 ppatch = a1 * 0.5f;

--- a/contrib/rovigatti/src/Interactions/old/CUDANathanStarInteraction.cu
+++ b/contrib/rovigatti/src/Interactions/old/CUDANathanStarInteraction.cu
@@ -179,7 +179,7 @@ __global__ void NS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *fo
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
+	c_number4 T = torques[IND];
 	c_number4 ppos = poss[IND];
 	GPU_quat po = orientations[IND];
 	c_number4 a1, a2, a3, b1, b2, b3;
@@ -213,7 +213,7 @@ __global__ void NS_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *fo
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
+	c_number4 T = torques[IND];
 	c_number4 ppos = poss[IND];
 	GPU_quat po = orientations[IND];
 	c_number4 a1, a2, a3, b1, b2, b3;

--- a/contrib/tostiguerra/src/CUDANNaMoInteraction.cu
+++ b/contrib/tostiguerra/src/CUDANNaMoInteraction.cu
@@ -292,7 +292,7 @@ __global__ void ps_bonded_forces(c_number4 *poss, GPU_quat *orientations, c_numb
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
+	c_number4 T = torques[IND];
 	c_number4 ppos = poss[IND];
 	c_number4 a1, a2, a3;
 	if(MD_enable_patch_stacking[0]) {

--- a/examples/METADYNAMICS/README.md
+++ b/examples/METADYNAMICS/README.md
@@ -25,6 +25,8 @@ Once launched, the script runs a certain number of metadynamics simulations that
 
 When used on CUDA-powered simulations, by default the interface launches the processes without any indication about the device that should be used, and in fact will honour the `CUDA_device` key if found in the base input file. Therefore, if GPUs are not set to run in compute mode "EXCLUSIVE_PROCESS", all the walkers will use the same GPU (the one specified by `CUDA_device` or, if this is not present in the base input file, the first available GPU). The `--use_sequential_GPUs` switch can be used to tell each walker to run on a distinct GPU: walker 0 will run on device 0, walker 1 on device 1, *etc.*
 
+Note that reproducible results (at least on CPU) can be obtained by using a seed, which can be specified with the `--seed` switch, or by using a `seed` key in the TOML configuration file. Any seed found in the base input file will be overwritten.
+
 ## Supported collective variables
 
 The interface provides the following collective variables (CVs). Below each CV we give a compact mathematical definition using the centre-of-mass positions of the selected nucleotide sets: for a set $A$ with $N_A$ particles we denote its centre of mass by

--- a/examples/METADYNAMICS/README.md
+++ b/examples/METADYNAMICS/README.md
@@ -155,13 +155,27 @@ potential_grid = comma-separated values
 
 ### Continuous coordination number (hydrogen-bond-based CV)
 
-For a set of hydrogen-bond candidate pairs indexed by $(i,j)$, with inter-particle distances $r_{ij}$, a smooth coordination number is defined as
+For a set of hydrogen-bond candidate pairs indexed by $(i,j)$, it is possible to define a smooth coordination number
+in two ways:
+
+1. If $U_{HB}(i,j)$ is the pair energy contribution due to hydrogen bonding between $i$ and $j$, then a smooth coordination number can be defined as
+$$
+C_{HB} = \sum_{(j, j)} \frac{1}{2} \left[ 1 + \tanh{\left( \frac{U_{\rm cut} - U_{HB}(i, j)}{U_w} \right)} \right],
+$$
+where $U_{\rm cut}$ and $U_w$ are two parameters that can be set with the `hb_energy_cutoff` and `hb_transition_width` TOML keys and whose values default to $-0.2$ and $0.1$, respectively. This CV can be set with `coordination_type = "hb_energy"`.
+2. Defining $r_{ij}$ as the distance between the HB sites of $i$ and $j$, a smooth coordination number can be defined as
+$$
+C_{sw} = \sum_{(i,j)} \frac{1}{1 + \left(\dfrac{r_{ij} - d_0}{r_0}\right)^n},
+$$
+where $d_0$, $r_0$, and $n$ are parameters controlling the switching function (see example configuration). This CV is continuous and bounded, and is the basis for the coordination-based metadynamics example. This CV can be selected by setting `coordination_type = "switching_function"` in the TOML input file. The default values for the $d_0$, $r_0$, and $n$ parameters are $0.4$, $0.5$, and $6$ (as in the example below), but different values can be used by setting the `d0`, `r0`, and `n` keys in the metadynamics TOML file.
+
+It is also possible to use a coordination number that is a combination of the two by setting `coordination_type = "mixed"`:
 
 $$
-C = \sum_{(i,j)} \frac{1}{1 + \left(\dfrac{r_{ij} - d_0}{r_0}\right)^n},
+C_{\rm tot} = w C_{HB} + (1 - w) C_{sw},
 $$
 
-where $d_0$, $r_0$, and $n$ are parameters controlling the switching function (see example configuration). This CV is continuous and bounded, and is the basis for the coordination-based metadynamics example.
+where $w \in [0, 1]$ is set with the `mixed_weight` option and defaults to $0.7$.
 
 Usage (brief):
 
@@ -172,7 +186,9 @@ Usage (brief):
 ```toml
 type = meta_coordination
 op_file = "path/to/op_file"   # order-parameter file listing hb pairs
-d0 = 1.2
+coordination_type = "mixed"
+hb_energy_cutoff = -0.1
+d0 = 0.4
 r0 = 0.5
 n = 6
 coord_min = 0.0
@@ -181,7 +197,7 @@ N_grid = 121
 potential_grid = comma-separated values
 ```
 
-The `op_file` must contain the hydrogen-bond definitions; the code will extract the list of pairs and compute the continuous coordination number using the switching parameters `d0`, `r0` and exponent `n`. Note that the default values for these parameters are $1.2$, $0.5$, and $6$ (as in the example above), but different values can be used by setting the `d0`, `r0`, and `n` keys in the metadynamics TOML file.
+The `op_file` must contain the hydrogen-bond definitions; the code will extract the list of pairs and compute the continuous coordination number using the switching parameters `d0`, `r0` and exponent `n`. Note that 
 
 ## Set up a metadynamics simulation
 

--- a/examples/METADYNAMICS/metad_interface.py
+++ b/examples/METADYNAMICS/metad_interface.py
@@ -8,6 +8,7 @@ import traceback
 import pickle as pkl
 import glob
 import toml
+import random
 
 try:
     import oxpy
@@ -390,7 +391,7 @@ class Estimator():
     def __init__(self, base_dir, dX=0.1, sigma=0.2, A=0.01, dT=10, Niter=200, tau=int(1e5), N_walkers=1, 
                 use_sequential_GPUs=False, p_fname="", dim=1, ratio=False, angle=False, coordination=False,
                 xmin=0, xmax=30, conf_interval=1000, save_hills=10, continue_run=False, T=None, 
-                op_interval: int=1000, **kw_args):
+                op_interval: int=1000, seed=None, **kw_args):
 
         if ratio:
             self.handler = AtanCOMTrapHandler(args.p_fname, args.xmin, args.xmax, args.dX)
@@ -422,6 +423,8 @@ class Estimator():
         self.save_hills = save_hills
         self.continue_run = continue_run
         self.op_interval = op_interval
+
+        random.seed(seed)
 
         # we update the spacing for integer division 
         if not self.continue_run:
@@ -520,6 +523,9 @@ class Estimator():
                     with open(os.path.join(w.working_dir, Estimator.INPUT_FILE), 'w+') as f:
                         if use_sequential_GPUs:
                             input_file["CUDA_device"] = str(w.index)
+
+                        input_file["seed"] = str(random.randint(0, int(1e9)))
+
                         f.write(str(input_file))
 
                     self.handler.prepare_folder(w.working_dir)
@@ -770,6 +776,7 @@ def build_parser():
     parser.add_argument("--save_hills", type=int, default=10, help="Potential sampling frequency")
     parser.add_argument("--T", default=None, help="Simulation temperature")
     parser.add_argument("--op_interval", type=int, default=1000, help="Order parameter print frequency")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducible results")
 
     # Boolean flags
     parser.add_argument("--continue_run", action="store_true", help="Continue previous simulation")

--- a/examples/METADYNAMICS/metad_interface.py
+++ b/examples/METADYNAMICS/metad_interface.py
@@ -53,11 +53,18 @@ class IForceHandler:
 
 
 class CoordinationHandler(IForceHandler):
-    def __init__(self, pfile: str, xmin: float, xmax: float, dx: float, d0: float = 0.4, r0: float = 0.5, n: int = 6):
+    def __init__(self, pfile: str, xmin: float, xmax: float, dx: float, 
+                 coordination_type: str = "hb_cutoff", mixed_weight: float = 0.7, 
+                 hb_energy_cutoff: float = -0.2, hb_transition_width: float = 0.1,
+                 d0: float = 0.4, r0: float = 0.5, n: int = 6):
         super().__init__(pfile, xmin, xmax, dx)
         self.d0 = d0
         self.r0 = r0
         self.n = n
+        self.coordination_type = coordination_type
+        self.mixed_weight = mixed_weight
+        self.hb_energy_cutoff = hb_energy_cutoff
+        self.hb_transition_width = hb_transition_width
 
     def parse_pfile(self, pfile: str):
         self.pairs = []
@@ -90,9 +97,13 @@ class CoordinationHandler(IForceHandler):
     col_1 = {{
         type = coordination
         op_file = op_coordination.dat
+        coordination_type = {self.coordination_type}
+        mixed_weight = {self.mixed_weight}
         d0 = {self.d0}
         r0 = {self.r0}
         n = {self.n}
+        hb_energy_cutoff = {self.hb_energy_cutoff}
+        hb_transition_width = {self.hb_transition_width}
     }}
     col_2 = {{
         type = force_energy
@@ -115,9 +126,13 @@ class CoordinationHandler(IForceHandler):
     N_grid = {self.N_grid}
     potential_grid = {grid_string}
     op_file = op_coordination.dat
+    coordination_type = {self.coordination_type}
+    mixed_weight = {self.mixed_weight}
     d0 = {self.d0}
     r0 = {self.r0}
     n = {self.n}
+    hb_energy_cutoff = {self.hb_energy_cutoff}
+    hb_transition_width = {self.hb_transition_width}
 }}
 '''
 
@@ -305,13 +320,14 @@ class AngleCOMTrapHandler(IForceHandler):
 
 class oxDNARunner(mp.Process):
 
-    def __init__(self, index, input_file, queue):
+    def __init__(self, index, input_file, queue, ready_event):
         mp.Process.__init__(self)
 
         self.index = index
         self.working_dir = f"{Estimator.RUN_BASEDIR}{index}"
         self.input_file = input_file
         self.queue = queue
+        self.ready_event = ready_event
         
         self._pconn, self._cconn = mp.Pipe()
         self._exception = None
@@ -319,34 +335,41 @@ class oxDNARunner(mp.Process):
     def run(self):
         os.chdir(self.working_dir)
         
-        with oxpy.Context():
-            input_file = oxpy.InputFile()
-            input_file.init_from_filename(self.input_file)
-            
-            self.manager = oxpy.OxpyManager(input_file)
-            
-            while True:
-                try:
-                    print_conf, steps, new_potential_grid = self.queue.get()
-                    if print_conf:
-                        self.manager.print_configuration()
-                    # if steps is None we have to break the loop and stop the walker
-                    if steps is not None:
-                        # update the lookup tables of all the metadynamics-related forces
-                        for force in self.manager.config_info().forces:
-                            if force.group_name == "metadynamics":
-                                force.potential_grid = new_potential_grid
-                        
-                        self.manager.run(steps)
-                    else:
-                        break
-                except Exception as e:
-                    # if an exception is raised we save the traceback and send it (together with the exception)
-                    # to this process' pipe, through which we can obtain and send it to the parent's process
-                    tb = traceback.format_exc()
-                    self._cconn.send((e, tb))
-                finally:
-                    self.queue.task_done()
+        try:
+            with oxpy.Context():
+                input_file = oxpy.InputFile()
+                input_file.init_from_filename(self.input_file)
+                
+                self.manager = oxpy.OxpyManager(input_file)
+                # Signal successful initialization
+                self.ready_event.set()
+                
+                while True:
+                    try:
+                        print_conf, steps, new_potential_grid = self.queue.get()
+                        if print_conf:
+                            self.manager.print_configuration()
+                        # if steps is None we have to break the loop and stop the walker
+                        if steps is not None:
+                            # update the lookup tables of all the metadynamics-related forces
+                            for force in self.manager.config_info().forces:
+                                if force.group_name == "metadynamics":
+                                    force.potential_grid = new_potential_grid
+                            
+                            self.manager.run(steps)
+                        else:
+                            break
+                    except Exception as e:
+                        # if an exception is raised we save the traceback and send it (together with the exception)
+                        # to this process' pipe, through which we can obtain and send it to the parent's process
+                        tb = traceback.format_exc()
+                        self._cconn.send((e, tb))
+                    finally:
+                        self.queue.task_done()
+        except Exception as e:
+            # Initialization errors (before entering the loop)
+            tb = traceback.format_exc()
+            self._cconn.send((e, tb))
                 
     @property
     def exception(self):
@@ -375,7 +398,7 @@ class Estimator():
             self.handler = AngleCOMTrapHandler(args.p_fname, args.xmin, args.xmax, args.dX)
         elif coordination:
             additional_args = {}
-            for key in "d0", "r0", "n": # optional arguments for the coordination CV
+            for key in "coordination_type", "mixed_weight", "d0", "r0", "n": # optional arguments for the coordination CV
                 if key in kw_args:
                     additional_args[key] = kw_args[key]
             self.handler = CoordinationHandler(args.p_fname, args.xmin, args.xmax, args.dX, **additional_args)
@@ -505,6 +528,20 @@ class Estimator():
         for w in self.walkers:
             self.write_external_forces_file(w.working_dir)
             w.start()
+        
+        # wait for all workers to initialize successfully
+        for i, ready_event in enumerate(self.ready_events):
+            if not ready_event.wait(timeout=2):
+                # timeout or error occurred
+                for w in self.walkers:
+                    if w.exception is not None:
+                        error, traceback = w.exception
+                        print(f"The following error was raised during the initialization of worker {w.index}:")
+                        print(error)
+                        print(traceback)
+                        exit(1)
+                print(f"CRITICAL: Worker {i} failed to initialize within timeout", file=sys.stderr)
+                exit(1)
                 
     def get_new_data(self, dir_name):
         # Read only the last sampled order parameter value
@@ -611,8 +648,11 @@ class Estimator():
     def _init_walkers(self):
         self.queue = mp.JoinableQueue()
         self.walkers = []
+        self.ready_events = []
         for walker_index in range(self.N_walkers):
-            self.walkers.append(oxDNARunner(walker_index, Estimator.INPUT_FILE, self.queue))
+            ready_event = mp.Event()
+            self.ready_events.append(ready_event)
+            self.walkers.append(oxDNARunner(walker_index, Estimator.INPUT_FILE, self.queue, ready_event))
             
     def stop_runners(self, print_last_conf=False):
         runner_args = [print_last_conf, None, 0]
@@ -631,9 +671,11 @@ class Estimator():
         for w in self.walkers:
             self.write_external_forces_file(w.working_dir)
             self.queue.put(runner_args)
+        
+        # wait for all workers to complete
         self.queue.join()
         
-        # check whether exceptions were raised by the walkers during the previous run
+        # check whether exceptions were raised by the walkers during execution
         for w in self.walkers:
             if w.exception is not None:
                 error, traceback = w.exception

--- a/examples/METADYNAMICS/metad_interface.py
+++ b/examples/METADYNAMICS/metad_interface.py
@@ -53,7 +53,7 @@ class IForceHandler:
 
 
 class CoordinationHandler(IForceHandler):
-    def __init__(self, pfile: str, xmin: float, xmax: float, dx: float, d0: float = 1.2, r0: float = 0.5, n: int = 6):
+    def __init__(self, pfile: str, xmin: float, xmax: float, dx: float, d0: float = 0.4, r0: float = 0.5, n: int = 6):
         super().__init__(pfile, xmin, xmax, dx)
         self.d0 = d0
         self.r0 = r0

--- a/examples/METADYNAMICS/metad_interface.py
+++ b/examples/METADYNAMICS/metad_interface.py
@@ -519,16 +519,19 @@ class Estimator():
                     shutil.copy(initial_conf, os.path.join(w.working_dir, Estimator.LAST_CONF))
                     shutil.copy(top_file, w.working_dir)
                     
-                    # write the meta input
-                    with open(os.path.join(w.working_dir, Estimator.INPUT_FILE), 'w+') as f:
-                        if use_sequential_GPUs:
-                            input_file["CUDA_device"] = str(w.index)
-
-                        input_file["seed"] = str(random.randint(0, int(1e9)))
-
-                        f.write(str(input_file))
-
                     self.handler.prepare_folder(w.working_dir)
+            
+            # now write the meta input. We need to do this independently of continue_run
+            # since in principle the user could want to restart the run with different parameters 
+            # (e.g. different number tau, conf_interval, etc)
+            for w in self.walkers:
+                with open(os.path.join(w.working_dir, Estimator.INPUT_FILE), 'w+') as f:
+                    if use_sequential_GPUs:
+                        input_file["CUDA_device"] = str(w.index)
+
+                    input_file["seed"] = str(random.randint(0, int(1e9)))
+
+                    f.write(str(input_file))
 
         # write the initial force files                
         for w in self.walkers:

--- a/examples/METADYNAMICS/prepare_sampling.py
+++ b/examples/METADYNAMICS/prepare_sampling.py
@@ -3,13 +3,13 @@
 import os, shutil
 import toml
 import oxpy
+import random
 
 BASE_RUNNER_DIR = "run-meta_0"
 RUNNER_INPUT_FILE = "input-meta"
 METAD_CONFIG_FILENAME = "original_metad_config.toml"
 
 FILES = {
-    RUNNER_INPUT_FILE : "input",
     "last_conf.dat" : "init_conf.dat",
     "ext_meta.txt" : "ext_meta.txt"
 }
@@ -19,7 +19,8 @@ LINES = {
     "log_file" : ["oxDNA_log.txt", ""],
     "no_stdout_energy" : ["true", ""],
     "print_conf_interval" : ["1e11", "1e5"],
-    "restart_step_counter" : ["", "true"]
+    "restart_step_counter" : ["", "true"],
+    "seed" : ["*", ""]
 }
 
 def build_parser():
@@ -33,6 +34,7 @@ def build_parser():
 
     parser.add_argument("--config", type=str, required=True, help="Path to the TOML configuration file printed by the metadynamics interface.")
     parser.add_argument("--force", "-f", action="store_true", help="Whether to overwrite the sampling folder if it already exists.")
+    parser.add_argument("--seed", "-s", type=int, default=random.randint(0, 2**32 - 1), help="The seed to use for the oxDNA simulation. If not given, the seed will be chosen randomly.")
 
     return parser
 
@@ -57,39 +59,33 @@ if __name__ == "__main__":
     # Copy also the metadynamics configuration file
     shutil.copy(args.config, os.path.join(args.sampling_dir, METAD_CONFIG_FILENAME))
 
-    # Read the name of the topology file from the input file
     with oxpy.Context(print_coda=False):
         input_file = oxpy.InputFile()
         input_file.init_from_filename(os.path.join(BASE_RUNNER_DIR, RUNNER_INPUT_FILE))
+        # Read the name of the topology file from the input file and add it to FILES so that it is copied over to the sampling dir
         topology_file = input_file["topology"]
-        FILES[topology_file] = topology_file # add it to FILES so that it is copied over to the sampling dir
+        FILES[topology_file] = topology_file
+
+        # Replace the lines of the input file that need to be changed to run the sampling
+        LINES["seed"][1] = f"{args.seed}"
+        for key in LINES:
+            if key in input_file:
+                option = input_file[key]
+                if LINES[key][0] != "" and LINES[key][0] != "*" and option != LINES[key][0]:
+                    print(f"Warning: the value of {key} in the input file is not {LINES[key][0]} as expected, but {option}. The line will be replaced anyway, but make sure that we are working with the correct input file.")
+
+            if LINES[key][1] == "" and key in input_file:
+                del input_file[key]
+            else:
+                input_file[key] = LINES[key][1]
+
+        # Print the modified input file to the sampling directory
+        input_filename = os.path.join(args.sampling_dir, "input")
+        with open(input_filename, "w") as f:
+            print(input_file, file=f)
 
     # Copy the base simulation files
     for f_old, f_new in FILES.items():
         src = os.path.join(BASE_RUNNER_DIR, f_old)
         dst = os.path.join(args.sampling_dir, f_new)
         shutil.copy(src, dst)
-
-    # Replace the lines of the input file that need to be changed to run the sampling
-    input_file = os.path.join(args.sampling_dir, "input")
-    with open(input_file, "r") as f:
-        lines = f.readlines()
-        lines_to_delete = []
-        for i in range(len(lines)):
-            spl = [s.strip() for s in lines[i].strip().split("=")]
-            if len(spl) == 2:
-                key, option = spl
-                if key in LINES:
-                    if LINES[key][0] != "" and option != LINES[key][0]:
-                        print(f"Warning: the value of {key} in the input file is not {LINES[key][0]} as expected, but {option}. The line will be replaced anyway, but make sure that we are working with the correct input file.")
-                    if LINES[key][1] == "":
-                        lines_to_delete.append(i)
-                    else:
-                        option = LINES[key][1]
-                        lines[i] = f"{key} = {option}\n"
-
-        for i in reversed(lines_to_delete):
-            del lines[i]
-
-    with open(input_file, "w") as f:
-        f.writelines(lines)

--- a/examples/METADYNAMICS/unbias_sampling.py
+++ b/examples/METADYNAMICS/unbias_sampling.py
@@ -89,6 +89,10 @@ if __name__ == "__main__":
     # defined as the proper number of hydrogen bonds, which is stored in the third column of the OP file
     if config_data["coordination"] == True:
         hb_biased_values = op_data[:, 2]
+
+        hb_biased_beta_FE = get_beta_FE(hb_biased_values, op_range=op_range)
+        np.savetxt("biased_hb_beta_FE.dat", np.column_stack(hb_biased_beta_FE))
+
         bins = list(range(int(op_max - op_min) + 1))
         hb_unbiased_beta_FE = get_beta_FE(hb_biased_values, weights=weights, bins=bins)
         np.savetxt("unbiased_hb_beta_FE.dat", np.column_stack(hb_unbiased_beta_FE))

--- a/examples/METADYNAMICS/unbias_sampling.py
+++ b/examples/METADYNAMICS/unbias_sampling.py
@@ -63,6 +63,9 @@ if __name__ == "__main__":
 
         dx = (op_max - op_min) / (N_grid - 1)
         op_grid = np.arange(op_min, op_max + dx, dx)
+        # it can happen that, due to rounding issues, op_grid has one more element than bias, so we need to trim it
+        if len(op_grid) > len(bias):
+            op_grid = op_grid[:len(bias)]
         np.savetxt("bias_from_force_file.dat", np.column_stack((op_grid, bias)))
 
     # Read the order parameter values from the OP file

--- a/src/Backends/MD_CPUBackend.cpp
+++ b/src/Backends/MD_CPUBackend.cpp
@@ -121,7 +121,10 @@ void MD_CPUBackend::_first_step() {
 			number ysin = LVersor[1] * sintheta;
 			number zsin = LVersor[2] * sintheta;
 
-			LR_matrix R(LVersor[0] * LVersor[0] * olcos + costheta, xyo - zsin, xzo + ysin, xyo + zsin, LVersor[1] * LVersor[1] * olcos + costheta, yzo - xsin, xzo - ysin, yzo + xsin, LVersor[2] * LVersor[2] * olcos + costheta);
+			LR_matrix R(
+				LVersor[0] * LVersor[0] * olcos + costheta, xyo - zsin, xzo + ysin, 
+				xyo + zsin, LVersor[1] * LVersor[1] * olcos + costheta, yzo - xsin, 
+				xzo - ysin, yzo + xsin, LVersor[2] * LVersor[2] * olcos + costheta);
 
 			p->orientation = p->orientation * R;
 			p->orientationT = p->orientation.get_transpose();
@@ -135,6 +138,11 @@ void MD_CPUBackend::_first_step() {
 	// position update since some external forces might depend on other particles' degrees of freedom
 	for(auto p : _particles) {
 		p->set_initial_forces(current_step(), _box.get());
+		// if(p->force.norm() > 0) {
+		// 	printf("%d: %g %g %g, %g %g %g\n", p->index, p->force.x, p->force.y, p->force.z, p->torque.x, p->torque.y, p->torque.z);
+		// 	LR_vector total_torque = p->torque + p->int_centers[2].cross(p->force);
+		// 	printf("Total torque: %g %g %g\n", total_torque.x, total_torque.y, total_torque.z);
+		// }
 	}
 
 	if(particles_with_warning.size() > 0) {

--- a/src/Backends/MD_CPUBackend.cpp
+++ b/src/Backends/MD_CPUBackend.cpp
@@ -134,31 +134,6 @@ void MD_CPUBackend::_first_step() {
 		_lists->single_update(p);
 	}
 
-	// Update the forces acting on the particles due to external fields. This has to be done after the 
-	// position update since some external forces might depend on other particles' degrees of freedom
-	for(auto p : _particles) {
-		p->set_initial_forces(current_step(), _box.get());
-		// if(p->force.norm() > 0) {
-		// 	printf("ID %d\n\t%g %g %g\n\t%g %g %g\n\t%g %g %g\n", p->index, 
-		// 		p->force.x, p->force.y, p->force.z, 
-		// 		p->torque.x, p->torque.y, p->torque.z,
-		// 		p->int_centers[2].cross(p->force).x, p->int_centers[2].cross(p->force).y, p->int_centers[2].cross(p->force).z);
-		// 	LR_vector total_torque = p->torque + p->int_centers[2].cross(p->force);
-		// 	printf("\t%g %g %g\n", total_torque.x, total_torque.y, total_torque.z);
-		// }
-	}
-
-	// LR_vector torque3 = _particles[3]->torque;
-	// LR_vector torque4 = _particles[4]->torque;
-	// LR_vector dist = CONFIG_INFO->box->min_image(_particles[4]->pos, _particles[3]->pos);
-	// LR_vector force_torque = dist.cross(_particles[3]->force);
-	// LR_vector tot = torque3 + torque4 + force_torque;
-	// printf("TORQUE3 %g %g %g\n", torque3.x, torque3.y, torque3.z);
-	// printf("TORQUE4 %g %g %g\n", torque4.x, torque4.y, torque4.z);
-	// printf("FORCE_TORQUE %g %g %g\n", force_torque.x, force_torque.y, force_torque.z);
-	// printf("DIST %g %g %g\n", dist.x, dist.y, dist.z);
-	// printf("TOT %g %g %g\n", tot.x, tot.y, tot.z);
-
 	if(particles_with_warning.size() > 0) {
 		std::stringstream ss;
 		for(auto idx : particles_with_warning) {
@@ -170,6 +145,12 @@ void MD_CPUBackend::_first_step() {
 
 void MD_CPUBackend::_compute_forces() {
 	_interaction->begin_energy_and_force_computation();
+
+	// Update the forces acting on the particles due to external fields. This has to be done after the 
+	// position update since some external forces might depend on other particles' degrees of freedom
+	for(auto p : _particles) {
+		p->set_initial_forces(current_step(), _box.get());
+	}
 
 	_U = (number) 0;
 	for(auto p : _particles) {

--- a/src/Backends/MD_CPUBackend.cpp
+++ b/src/Backends/MD_CPUBackend.cpp
@@ -128,9 +128,13 @@ void MD_CPUBackend::_first_step() {
 			p->set_positions();
 		}
 
-		p->set_initial_forces(current_step(), _box.get());
-
 		_lists->single_update(p);
+	}
+
+	// Update the forces acting on the particles due to external fields. This has to be done after the 
+	// position update since some external forces might depend on other particles' degrees of freedom
+	for(auto p : _particles) {
+		p->set_initial_forces(current_step(), _box.get());
 	}
 
 	if(particles_with_warning.size() > 0) {

--- a/src/Backends/MD_CPUBackend.cpp
+++ b/src/Backends/MD_CPUBackend.cpp
@@ -139,11 +139,25 @@ void MD_CPUBackend::_first_step() {
 	for(auto p : _particles) {
 		p->set_initial_forces(current_step(), _box.get());
 		// if(p->force.norm() > 0) {
-		// 	printf("%d: %g %g %g, %g %g %g\n", p->index, p->force.x, p->force.y, p->force.z, p->torque.x, p->torque.y, p->torque.z);
+		// 	printf("ID %d\n\t%g %g %g\n\t%g %g %g\n\t%g %g %g\n", p->index, 
+		// 		p->force.x, p->force.y, p->force.z, 
+		// 		p->torque.x, p->torque.y, p->torque.z,
+		// 		p->int_centers[2].cross(p->force).x, p->int_centers[2].cross(p->force).y, p->int_centers[2].cross(p->force).z);
 		// 	LR_vector total_torque = p->torque + p->int_centers[2].cross(p->force);
-		// 	printf("Total torque: %g %g %g\n", total_torque.x, total_torque.y, total_torque.z);
+		// 	printf("\t%g %g %g\n", total_torque.x, total_torque.y, total_torque.z);
 		// }
 	}
+
+	// LR_vector torque3 = _particles[3]->torque;
+	// LR_vector torque4 = _particles[4]->torque;
+	// LR_vector dist = CONFIG_INFO->box->min_image(_particles[4]->pos, _particles[3]->pos);
+	// LR_vector force_torque = dist.cross(_particles[3]->force);
+	// LR_vector tot = torque3 + torque4 + force_torque;
+	// printf("TORQUE3 %g %g %g\n", torque3.x, torque3.y, torque3.z);
+	// printf("TORQUE4 %g %g %g\n", torque4.x, torque4.y, torque4.z);
+	// printf("FORCE_TORQUE %g %g %g\n", force_torque.x, force_torque.y, force_torque.z);
+	// printf("DIST %g %g %g\n", dist.x, dist.y, dist.z);
+	// printf("TOT %g %g %g\n", tot.x, tot.y, tot.z);
 
 	if(particles_with_warning.size() > 0) {
 		std::stringstream ss;

--- a/src/CUDA/Backends/CUDA_MD.cuh
+++ b/src/CUDA/Backends/CUDA_MD.cuh
@@ -106,6 +106,7 @@ __global__ void set_external_forces(c_number4 *poss, GPU_quat *orientations, CUD
 	c_number4 ppos = poss[IND];
 	c_number4 F = make_c_number4(0, 0, 0, 0);
 	c_number4 T = make_c_number4(0, 0, 0, 0);
+	bool update_torque = false;
 
 	for(int i = 0; i < max_ext_forces; i++) {
 		// coalesced
@@ -508,6 +509,13 @@ __global__ void set_external_forces(c_number4 *poss, GPU_quat *orientations, CUD
 				}
 				break;
 			}
+			case CUDA_LR_COORDINATION: {
+				update_torque = true;
+
+				cuda_meta::lt_coordination_force_torque(&extF.ltcoordination, IND, poss, orientations, ppos, F, T, box);
+				break;
+				
+			}
 			case CUDA_YUKAWA_SPHERE: {
 				c_number4 centre = make_c_number4(extF.yukawasphere.center.x, extF.yukawasphere.center.y, extF.yukawasphere.center.z, 0.);
 
@@ -542,6 +550,13 @@ __global__ void set_external_forces(c_number4 *poss, GPU_quat *orientations, CUD
 				break;
 			}
 		}
+	}
+
+	if(update_torque) {
+		GPU_quat po = orientations[IND];
+		c_number4 a1, a2, a3;
+		get_vectors_from_quat(po, a1, a2, a3);
+		T = _vectors_transpose_c_number4_product(a1, a2, a3, T);
 	}
 
 	forces[IND] = F;

--- a/src/CUDA/Backends/CUDA_MD.cuh
+++ b/src/CUDA/Backends/CUDA_MD.cuh
@@ -106,7 +106,6 @@ __global__ void set_external_forces(c_number4 *poss, GPU_quat *orientations, CUD
 	c_number4 ppos = poss[IND];
 	c_number4 F = make_c_number4(0, 0, 0, 0);
 	c_number4 T = make_c_number4(0, 0, 0, 0);
-	bool update_torque = false;
 
 	for(int i = 0; i < max_ext_forces; i++) {
 		// coalesced
@@ -510,8 +509,6 @@ __global__ void set_external_forces(c_number4 *poss, GPU_quat *orientations, CUD
 				break;
 			}
 			case CUDA_LR_COORDINATION: {
-				update_torque = true;
-
 				cuda_meta::lt_coordination_force_torque(&extF.ltcoordination, IND, poss, orientations, ppos, F, T, box);
 				break;
 				
@@ -550,13 +547,6 @@ __global__ void set_external_forces(c_number4 *poss, GPU_quat *orientations, CUD
 				break;
 			}
 		}
-	}
-
-	if(update_torque) {
-		GPU_quat po = orientations[IND];
-		c_number4 a1, a2, a3;
-		get_vectors_from_quat(po, a1, a2, a3);
-		T = _vectors_transpose_c_number4_product(a1, a2, a3, T);
 	}
 
 	forces[IND] = F;

--- a/src/CUDA/Backends/CUDA_mixed.cuh
+++ b/src/CUDA/Backends/CUDA_mixed.cuh
@@ -50,7 +50,7 @@ __global__ void first_step_mixed(float4 __restrict__ *poss, GPU_quat __restrict_
 	if(any_rigid_body) {
 		float4 T = torques[IND];
 		LR_double4 L = Lsd[IND];
-		
+
 		L.x += T.x * MD_dt[0] * 0.5f;
 		L.y += T.y * MD_dt[0] * 0.5f;
 		L.z += T.z * MD_dt[0] * 0.5f;

--- a/src/CUDA/Backends/MD_CUDABackend.cu
+++ b/src/CUDA/Backends/MD_CUDABackend.cu
@@ -7,7 +7,7 @@
 
 #include "MD_CUDABackend.h"
 
-#include "../CUDAForces.h"
+#include "../Forces/forces_defs.cuh"
 #include "CUDA_MD.cuh"
 #include "../../Interactions/DNAInteraction.h"
 #include "../../Observables/ObservableOutput.h"
@@ -171,7 +171,6 @@ void MD_CUDABackend::_apply_external_forces_changes() {
 					RepulsiveSphereSmooth *p_force = (RepulsiveSphereSmooth *) p->ext_forces[j];
 					init_RepulsiveSphereSmooth_from_CPU(&cuda_force->repulsivespheresmooth, p_force);
 				}
-				
 				else if(force_type == typeid(RepulsiveSphereMoving)) {
 					RepulsiveSphereMoving *p_force = (RepulsiveSphereMoving *) p->ext_forces[j];
 					init_RepulsiveSphereMoving_from_CPU(&cuda_force->repulsivespheremoving, p_force);
@@ -207,6 +206,10 @@ void MD_CUDABackend::_apply_external_forces_changes() {
 				else if(force_type == typeid(LTCOMTrap)) {
 					LTCOMTrap *p_force = (LTCOMTrap *) p->ext_forces[j];
 					init_LTCOMTrap_from_CPU(&cuda_force->ltcomtrap, p_force, first_time);
+				}
+				else if(force_type == typeid(LTCoordination)) {
+					LTCoordination *p_force = (LTCoordination *) p->ext_forces[j];
+					init_LTCoordination_from_CPU(&cuda_force->ltcoordination, p_force, p->index, first_time);
 				}
 				else if(force_type == typeid(YukawaSphere)) {
 					YukawaSphere *p_force = (YukawaSphere *) p->ext_forces[j];

--- a/src/CUDA/Forces/forces_defs.cuh
+++ b/src/CUDA/Forces/forces_defs.cuh
@@ -1,35 +1,11 @@
 /*
- * CUDAForces.h
+ * forces_defs.cuh
  *
  *  Created on: 26/giu/2013
  *      Author: lorenzo
  */
-
 #ifndef CUDAFORCES_H_
 #define CUDAFORCES_H_
-
-#include "../Forces/COMForce.h"
-#include "../Forces/ConstantRateForce.h"
-#include "../Forces/ConstantRateTorque.h"
-#include "../Forces/ConstantTrap.h"
-#include "../Forces/LowdimMovingTrap.h"
-#include "../Forces/MovingTrap.h"
-#include "../Forces/MutualTrap.h"
-#include "../Forces/RepulsionPlane.h"
-#include "../Forces/RepulsionPlaneMoving.h"
-#include "../Forces/RepulsiveSphere.h"
-#include "../Forces/RepulsiveSphereSmooth.h"
-#include "../Forces/RepulsiveSphereMoving.h"
-#include "../Forces/RepulsiveKeplerPoinsot.h"
-#include "../Forces/LJWall.h"
-#include "../Forces/GenericCentralForce.h"
-#include "../Forces/LJCone.h"
-#include "../Forces/RepulsiveEllipsoid.h"
-#include "../Forces/YukawaSphere.h"
-#include "../Forces/Metadynamics/LTCOMTrap.h"
-#include "../Forces/AttractionPlane.h"
-
-#include "CUDAUtils.h"
 
 #define CUDA_TRAP_NO_FORCE -1
 #define CUDA_TRAP_CONSTANT 0
@@ -51,7 +27,31 @@
 #define CUDA_ATTRACTION_PLANE 16
 #define CUDA_REPULSIVE_SPHERE_MOVING 17
 #define CUDA_REPULSIVE_KEPLER_POINSOT 18
+#define CUDA_LR_COORDINATION 19
 
+#include "../../Forces/COMForce.h"
+#include "../../Forces/ConstantRateForce.h"
+#include "../../Forces/ConstantRateTorque.h"
+#include "../../Forces/ConstantTrap.h"
+#include "../../Forces/LowdimMovingTrap.h"
+#include "../../Forces/MovingTrap.h"
+#include "../../Forces/MutualTrap.h"
+#include "../../Forces/RepulsionPlane.h"
+#include "../../Forces/RepulsionPlaneMoving.h"
+#include "../../Forces/RepulsiveSphere.h"
+#include "../../Forces/RepulsiveSphereSmooth.h"
+#include "../../Forces/RepulsiveSphereMoving.h"
+#include "../../Forces/RepulsiveKeplerPoinsot.h"
+#include "../../Forces/LJWall.h"
+#include "../../Forces/GenericCentralForce.h"
+#include "../../Forces/LJCone.h"
+#include "../../Forces/RepulsiveEllipsoid.h"
+#include "../../Forces/YukawaSphere.h"
+#include "../../Forces/AttractionPlane.h"
+
+#include "metad_forces.cuh"
+
+#include "../CUDAUtils.h"
 
 /**
  * @brief CUDA version of a ConstantRateForce.
@@ -393,66 +393,6 @@ void init_COMForce_from_CPU(COM_force *cuda_force, COMForce *cpu_force, bool fir
 }
 
 /**
- * @brief CUDA version of a COMForce.
- */
-struct lt_com_trap {
-	int type;
-
-	int p1a_size;
-	int p2a_size;
-    int *p1a;
-    int *p2a;
-
-    int xmin;
-    int xmax;
-    int N_grid;
-
-    c_number dX;
-    c_number *potential_grid;
-
-    int mode;
-	bool PBC;
-};
-
-void init_LTCOMTrap_from_CPU(lt_com_trap *cuda_force, LTCOMTrap *cpu_force, bool first_time) {
-	cuda_force->type = CUDA_LR_COM_TRAP;
-	cuda_force->xmin = cpu_force->xmin;
-	cuda_force->xmax = cpu_force->xmax;
-	cuda_force->N_grid = cpu_force->N_grid;
-	cuda_force->dX = cpu_force->dX;
-	cuda_force->mode = cpu_force->_mode;
-	cuda_force->PBC = cpu_force->PBC;
-	cuda_force->p1a_size = cpu_force->_p1a_ptr.size();
-	cuda_force->p2a_size = cpu_force->_p2a_ptr.size();
-
-	// copy the particle arrays
-	std::vector<int> local_p1a;
-	for(auto particle : cpu_force->_p1a_ptr) {
-		local_p1a.push_back(particle->index);
-	}
-	std::vector<int> local_p2a;
-	for(auto particle : cpu_force->_p2a_ptr) {
-		local_p2a.push_back(particle->index);
-	}
-
-	// copy the potential array
-	std::vector<c_number> local_grid;
-	for(auto v : cpu_force->potential_grid) {
-		local_grid.push_back(v);
-	}
-
-	if(first_time) {
-		// TODO: this memory never gets free'd
-		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<int>(&cuda_force->p1a, sizeof(int) * local_p1a.size()));
-		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<int>(&cuda_force->p2a, sizeof(int) * local_p2a.size()));
-		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<c_number>(&cuda_force->potential_grid, sizeof(c_number) * local_grid.size()));
-	}
-	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->p1a, local_p1a.data(), sizeof(int) * local_p1a.size(), cudaMemcpyHostToDevice));
-	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->p2a, local_p2a.data(), sizeof(int) * local_p2a.size(), cudaMemcpyHostToDevice));
-	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->potential_grid, local_grid.data(), sizeof(c_number) * local_grid.size(), cudaMemcpyHostToDevice));
-}
-
-/**
  * @brief CUDA version of a YukawaSphere.
  */
 struct Yukawa_sphere {
@@ -564,6 +504,7 @@ union CUDA_trap {
 	repulsive_ellipsoid repulsiveellipsoid;
 	COM_force comforce;
 	lt_com_trap ltcomtrap;
+	lt_coordination ltcoordination;
 	Yukawa_sphere yukawasphere;
 	attraction_plane attractionplane;
 	repulsive_sphere_moving repulsivespheremoving;

--- a/src/CUDA/Forces/metad_forces.cuh
+++ b/src/CUDA/Forces/metad_forces.cuh
@@ -278,37 +278,39 @@ __device__ c_number hb_interaction(const c_number4 &r, const c_number4 &rhydro, 
 		if(compute_F_T && hb_energy != 0.f) {
 			// derivatives called at the relevant arguments
 			c_number f1D = _f1D(rhydromod);
-			c_number f4t1D = -_f4D(t1, HYDR_THETA1_T0, HYDR_THETA1_A);
-			c_number f4t2D = -_f4D(t2, HYDR_THETA2_T0, HYDR_THETA2_A);
-			c_number f4t3D = _f4D(t3, HYDR_THETA3_T0, HYDR_THETA3_A);
-			c_number f4t4D = _f4D(t4, HYDR_THETA4_T0, HYDR_THETA4_A);
-			c_number f4t7D = -_f4D(t7, HYDR_THETA7_T0, HYDR_THETA7_A);
-			c_number f4t8D = _f4D(t8, HYDR_THETA8_T0, HYDR_THETA8_A);
+			c_number f4t1D =  _f4D(t1, HYDR_THETA1_T0, HYDR_THETA1_A);
+			c_number f4t2D =  _f4D(t2, HYDR_THETA2_T0, HYDR_THETA2_A);
+			c_number f4t3D = -_f4D(t3, HYDR_THETA3_T0, HYDR_THETA3_A);
+			c_number f4t4D = -_f4D(t4, HYDR_THETA4_T0, HYDR_THETA4_A);
+			c_number f4t7D =  _f4D(t7, HYDR_THETA7_T0, HYDR_THETA7_A);
+			c_number f4t8D = -_f4D(t8, HYDR_THETA8_T0, HYDR_THETA8_A);
 
 			// RADIAL PART
-			c_number4 Ftmp = rhydrodir * hb_energy * f1D / f1;
+			c_number4 Ftmp = -rhydrodir * (f1D * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8);
 
 			// TETA4; t4 = LRACOS (a3 * b3);
-			*T += stably_normalised(_cross(a3, b3)) * (hb_energy * f4t4D / f4t4);
+			*T += stably_normalised(_cross(a3, b3)) * (-f1 * f4t1 * f4t2 * f4t3 * f4t4D * f4t7 * f4t8);
 
 			// TETA1; t1 = LRACOS (-a1 * b1);
-			*T += stably_normalised(_cross(a1, b1)) * (hb_energy * f4t1D / f4t1);
+			*T += stably_normalised(_cross(a1, b1)) * (-f1 * f4t1D * f4t2 * f4t3 * f4t4 * f4t7 * f4t8);
 
 			// TETA2; t2 = LRACOS (-b1 * rhydrodir);
-			Ftmp -= stably_normalised(b1 + rhydrodir * cost2) * (hb_energy * f4t2D / (f4t2 * rhydromod));
+            number fact = f1 * f4t1 * f4t2D * f4t3 * f4t4 * f4t7 * f4t8;
+			Ftmp += stably_normalised(b1 + rhydrodir * cost2) * (fact / rhydromod);
 
 			// TETA3; t3 = LRACOS (a1 * rhydrodir);
-			c_number part = -hb_energy * f4t3D / f4t3;
-			Ftmp += stably_normalised(a1 - rhydrodir * cost3) * (part / rhydromod);
-			*T += stably_normalised(_cross(rhydrodir, a1)) * part;
+            fact = f1 * f4t1 * f4t2 * f4t3D * f4t4 * f4t7 * f4t8;
+			Ftmp += stably_normalised(a1 - rhydrodir * cost3) * (fact / rhydromod);
+			*T += stably_normalised(_cross(rhydrodir, a1)) * fact;
 
 			// THETA7; t7 = LRACOS (-rhydrodir * b3);
-			Ftmp -= stably_normalised(b3 + rhydrodir * cost7) * (hb_energy * f4t7D / (f4t7 * rhydromod));
+            fact = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7D * f4t8;
+			Ftmp += stably_normalised(b3 + rhydrodir * cost7) * (fact / rhydromod);
 
 			// THETA 8; t8 = LRACOS (rhydrodir * a3);
-			part = -hb_energy * f4t8D / f4t8;
-			Ftmp += stably_normalised(a3 - rhydrodir * cost8) * (part / rhydromod);
-			*T += stably_normalised(_cross(rhydrodir, a3)) * part;
+			fact = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8D;
+			Ftmp += stably_normalised(a3 - rhydrodir * cost8) * (fact / rhydromod);
+			*T += stably_normalised(_cross(rhydrodir, a3)) * fact;
 
 			*T += _cross(ppos_base, Ftmp);
 

--- a/src/CUDA/Forces/metad_forces.cuh
+++ b/src/CUDA/Forces/metad_forces.cuh
@@ -1,0 +1,468 @@
+/*
+ * metad_forces.cuh
+ *
+ *  Created on: 07/may/2026
+ *      Author: lorenzo
+ */
+#ifndef METAD_FORCES_H_
+#define METAD_FORCES_H_
+
+#include "../../Forces/Metadynamics/LTCOMTrap.h"
+#include "../../Forces/Metadynamics/LTCoordination.h"
+
+#include "../cuda_utils/CUDA_lr_common.cuh"
+#include "../../model.h"
+
+/**
+ * @brief CUDA version of a LTCOMTrap force.
+ */
+struct lt_com_trap {
+	int type;
+
+	int p1a_size;
+	int p2a_size;
+    int *p1a;
+    int *p2a;
+
+    int xmin;
+    int xmax;
+    int N_grid;
+
+    c_number dX;
+    c_number *potential_grid;
+
+    int mode;
+	bool PBC;
+};
+
+void init_LTCOMTrap_from_CPU(lt_com_trap *cuda_force, LTCOMTrap *cpu_force, bool first_time) {
+	cuda_force->type = CUDA_LR_COM_TRAP;
+	cuda_force->xmin = cpu_force->xmin;
+	cuda_force->xmax = cpu_force->xmax;
+	cuda_force->N_grid = cpu_force->N_grid;
+	cuda_force->dX = cpu_force->dX;
+	cuda_force->mode = cpu_force->_mode;
+	cuda_force->PBC = cpu_force->PBC;
+	cuda_force->p1a_size = cpu_force->_p1a_ptr.size();
+	cuda_force->p2a_size = cpu_force->_p2a_ptr.size();
+
+	// copy the particle arrays
+	std::vector<int> local_p1a;
+	for(auto particle : cpu_force->_p1a_ptr) {
+		local_p1a.push_back(particle->index);
+	}
+	std::vector<int> local_p2a;
+	for(auto particle : cpu_force->_p2a_ptr) {
+		local_p2a.push_back(particle->index);
+	}
+
+	// copy the potential array
+	std::vector<c_number> local_grid;
+	for(auto v : cpu_force->potential_grid) {
+		local_grid.push_back(v);
+	}
+
+	if(first_time) {
+		// TODO: this memory never gets free'd
+		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<int>(&cuda_force->p1a, sizeof(int) * local_p1a.size()));
+		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<int>(&cuda_force->p2a, sizeof(int) * local_p2a.size()));
+		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<c_number>(&cuda_force->potential_grid, sizeof(c_number) * local_grid.size()));
+	}
+	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->p1a, local_p1a.data(), sizeof(int) * local_p1a.size(), cudaMemcpyHostToDevice));
+	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->p2a, local_p2a.data(), sizeof(int) * local_p2a.size(), cudaMemcpyHostToDevice));
+	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->potential_grid, local_grid.data(), sizeof(c_number) * local_grid.size(), cudaMemcpyHostToDevice));
+}
+
+/**
+ * @brief CUDA version of a LTCOMTrap force.
+ */
+struct lt_coordination {
+	int type;
+
+	int2 *pairs;
+	int n_pairs;
+	int idx_other;
+
+	meta::CoordSettings::CoordMode coord_mode;
+	// only used if coord_mode == MIXED, must be between 0 and 1. The contribution of the HB_ENERGY mode will be multiplied 
+	// by this weight, while the contribution of the SWITCHING_FUNCTION mode will be multiplied by (1 - mixed_weight)
+	c_number mixed_weight;
+	c_number hb_energy_cutoff, hb_transition_width, d0, r0;
+	int n;
+
+    int coord_min;
+    int coord_max;
+	c_number d_coord;
+    int N_grid;
+    c_number *potential_grid;
+};
+
+void init_LTCoordination_from_CPU(lt_coordination *cuda_force, LTCoordination *cpu_force, int p_index, bool first_time) {
+	cuda_force->type = CUDA_LR_COORDINATION;
+	cuda_force->mixed_weight = cpu_force->settings.mixed_weight;
+	cuda_force->coord_mode = cpu_force->settings.coord_mode;
+	cuda_force->hb_energy_cutoff = cpu_force->settings.hb_energy_cutoff;
+	cuda_force->hb_transition_width = cpu_force->settings.hb_transition_width;
+	cuda_force->d0 = cpu_force->settings.d0;
+	cuda_force->r0 = cpu_force->settings.r0;
+	cuda_force->n = cpu_force->settings.n;
+	cuda_force->coord_min = cpu_force->coord_min;
+	cuda_force->coord_max = cpu_force->coord_max;
+	cuda_force->d_coord = cpu_force->d_coord;
+	cuda_force->N_grid = cpu_force->N_grid;
+
+	// copy the pairs array
+	std::vector<int2> local_pairs;
+	for(auto &pair : cpu_force->all_pairs) {
+		local_pairs.push_back(make_int2(pair.first->index, pair.second->index));
+        if(pair.first->index == p_index) {
+            cuda_force->idx_other = pair.second->index;
+        }
+        else if(pair.second->index == p_index) {
+            cuda_force->idx_other = pair.first->index;
+        }
+	}
+	cuda_force->n_pairs = local_pairs.size();
+
+	// copy the potential array
+	std::vector<c_number> local_grid;
+	for(auto v : cpu_force->potential_grid) {
+		local_grid.push_back(v);
+	}
+
+	if(first_time) {
+		// TODO: this memory never gets free'd
+		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<int2>(&cuda_force->pairs, sizeof(int2) * local_pairs.size()));
+		CUDA_SAFE_CALL(GpuUtils::LR_cudaMalloc<c_number>(&cuda_force->potential_grid, sizeof(c_number) * local_grid.size()));
+	}
+	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->pairs, local_pairs.data(), sizeof(int2) * local_pairs.size(), cudaMemcpyHostToDevice));
+	CUDA_SAFE_CALL(cudaMemcpy(cuda_force->potential_grid, local_grid.data(), sizeof(c_number) * local_grid.size(), cudaMemcpyHostToDevice));
+}
+
+namespace cuda_meta {
+
+__device__ inline c_number _f1(c_number r) {
+    // this should be pre-computed
+	c_number shift = HYDR_EPS_OXDNA2 * SQR(1.0 - exp(-(HYDR_RC - HYDR_R0) * HYDR_A));
+	
+	c_number val = 0.0f;
+	if(r < HYDR_RCHIGH) {
+		c_number tmp = 1.0f - expf(-(r - HYDR_R0) * HYDR_A);
+		val = HYDR_EPS_OXDNA2 * SQR(tmp) - shift;
+	}
+	return val;
+}
+
+__device__ inline c_number _f1D(c_number r) {
+	c_number val = 0.0f;
+	if(r < HYDR_RCHIGH) {
+		c_number tmp = expf(-(r - HYDR_R0) * HYDR_A);
+		val = 2.0f * HYDR_EPS_OXDNA2 * (1.0f - tmp) * tmp * HYDR_A;
+	}
+
+	return val;
+}
+
+__device__ inline c_number _f4(c_number t, c_number t0, c_number a) {
+	c_number val = 0.0f;
+	t -= t0;
+	if(t < 0.0f) {
+		t *= -1.0f;
+	}
+	if(t < 1.0f / sqrtf(a)) {
+		val = 1.0f - a * t * t;
+	}
+	return val;
+}
+
+__device__ inline c_number _f4D(c_number t, c_number t0, c_number a) {
+	c_number val = 0.0f;
+	c_number m = 1.0f;
+	c_number tt0 = t - t0;
+	if(tt0 < 0.0f) {
+		tt0 *= -1.0f;
+		m = -1.0f;
+	}
+	if(tt0 < 1.0f / sqrtf(a)) {
+		val = m * 2.0f * a * tt0;
+	}
+	return val;
+}
+
+__device__ inline c_number smooth_hb_contribution(c_number hb_energy_cutoff, c_number hb_transition_width, c_number hb_energy) {
+	c_number x = (hb_energy_cutoff - hb_energy) / hb_transition_width;
+	
+	if(x > 10.0f) return 1.0f;
+	if(x < -10.0f) return 0.0f;
+
+	return 0.5f * (1.0f + tanhf(x));
+}
+
+__device__ inline c_number der_smooth_hb_contribution(c_number hb_energy_cutoff, c_number hb_transition_width, c_number hb_energy) {
+	c_number x = (hb_energy_cutoff - hb_energy) / hb_transition_width;
+	
+	if(x > 10.0f) return 0.0f;
+	if(x < -10.0f) return 0.0f;
+
+	c_number tanh_x = tanhf(x);
+	return -0.5f * (1.0f - SQR(tanh_x)) / hb_transition_width;
+}
+
+// Interpolate potential grid to get potential value at coordinate x
+__device__ inline c_number interpolate_potential(c_number my_x, c_number dX, c_number xmin, const c_number *potential_grid, int N_grid) {
+	int ix_left = (int)floorf((my_x - xmin) / dX);
+	int ix_right = ix_left + 1;
+
+	if(ix_left < 0 || ix_right >= N_grid) return 0.0f;
+
+	c_number x_left = xmin + ix_left * dX;
+	c_number w_right = (my_x - x_left) / dX;
+	c_number w_left = 1.0f - w_right;
+
+	return w_left * potential_grid[ix_left] + w_right * potential_grid[ix_right];
+}
+
+// Get derivative of potential at coordinate x
+__device__ inline c_number get_x_force(c_number my_x, c_number dX, c_number xmin, const c_number *potential_grid, int N_grid) {
+	int ix_left = (int)floorf((my_x - xmin) / dX);
+	int ix_right = ix_left + 1;
+
+	if(ix_left < 0 || ix_right >= N_grid) return 0.0f;
+
+	return -(potential_grid[ix_right] - potential_grid[ix_left]) / dX;
+}
+
+// F and T are pointers so that they can be nullptr (which makes sense if compute_F_T is false)
+__device__ c_number hb_interaction(const c_number4 &r, const c_number4 &rhydro, const c_number4 &ppos, const c_number4 &a1, 
+    const c_number4 &a3, const c_number4 &qpos, const c_number4 &b1, const c_number4 &b3, c_number4 *F, c_number4 *T, 
+    bool compute_F_T) {
+
+    int ptype = get_particle_type(ppos);
+	int qtype = get_particle_type(qpos);
+	int pbtype = get_particle_btype(ppos);
+	int qbtype = get_particle_btype(qpos);
+	int int_type = pbtype + qbtype;
+
+	c_number4 ppos_base = POS_BASE * a1;
+
+    c_number hb_energy = 0.f;
+	c_number rhydromodsqr = CUDA_DOT(rhydro, rhydro);
+	if(int_type == 3 && SQR(HYDR_RCLOW) < rhydromodsqr && rhydromodsqr < SQR(HYDR_RCHIGH)) {
+		// versor and magnitude of the base-base separation
+		c_number rhydromod = sqrtf(rhydromodsqr);
+		c_number4 rhydrodir = rhydro / rhydromod;
+
+		// angles involved in the HB interaction
+		c_number t1 = CUDA_LRACOS(-CUDA_DOT(a1, b1));
+		c_number cost2 = -CUDA_DOT(b1, rhydrodir);
+		c_number t2 = CUDA_LRACOS(cost2);
+		c_number cost3 = CUDA_DOT(a1, rhydrodir);
+		c_number t3 = CUDA_LRACOS(cost3);
+		c_number t4 = CUDA_LRACOS(CUDA_DOT(a3, b3));
+		c_number cost7 = -CUDA_DOT(rhydrodir, b3);
+		c_number t7 = CUDA_LRACOS(cost7);
+		c_number cost8 = CUDA_DOT(rhydrodir, a3);
+		c_number t8 = CUDA_LRACOS(cost8);
+        
+		// functions called at their relevant arguments
+		c_number f1 = _f1(rhydromod);
+		c_number f4t1 = _f4(t1, HYDR_THETA1_T0, HYDR_THETA1_A);
+		c_number f4t2 = _f4(t2, HYDR_THETA2_T0, HYDR_THETA2_A);
+		c_number f4t3 = _f4(t3, HYDR_THETA3_T0, HYDR_THETA3_A);
+		c_number f4t4 = _f4(t4, HYDR_THETA4_T0, HYDR_THETA4_A);
+		c_number f4t7 = _f4(t7, HYDR_THETA7_T0, HYDR_THETA7_A);
+		c_number f4t8 = _f4(t8, HYDR_THETA8_T0, HYDR_THETA8_A);
+
+		hb_energy = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8;
+
+		if(compute_F_T && hb_energy != 0.f) {
+			// derivatives called at the relevant arguments
+			c_number f1D = _f1D(rhydromod);
+			c_number f4t1D = -_f4D(t1, HYDR_THETA1_T0, HYDR_THETA1_A);
+			c_number f4t2D = -_f4D(t2, HYDR_THETA2_T0, HYDR_THETA2_A);
+			c_number f4t3D = _f4D(t3, HYDR_THETA3_T0, HYDR_THETA3_A);
+			c_number f4t4D = _f4D(t4, HYDR_THETA4_T0, HYDR_THETA4_A);
+			c_number f4t7D = -_f4D(t7, HYDR_THETA7_T0, HYDR_THETA7_A);
+			c_number f4t8D = _f4D(t8, HYDR_THETA8_T0, HYDR_THETA8_A);
+
+			// RADIAL PART
+			c_number4 Ftmp = rhydrodir * hb_energy * f1D / f1;
+
+			// TETA4; t4 = LRACOS (a3 * b3);
+			*T += stably_normalised(_cross(a3, b3)) * (hb_energy * f4t4D / f4t4);
+
+			// TETA1; t1 = LRACOS (-a1 * b1);
+			*T += stably_normalised(_cross(a1, b1)) * (hb_energy * f4t1D / f4t1);
+
+			// TETA2; t2 = LRACOS (-b1 * rhydrodir);
+			Ftmp -= stably_normalised(b1 + rhydrodir * cost2) * (hb_energy * f4t2D / (f4t2 * rhydromod));
+
+			// TETA3; t3 = LRACOS (a1 * rhydrodir);
+			c_number part = -hb_energy * f4t3D / f4t3;
+			Ftmp += stably_normalised(a1 - rhydrodir * cost3) * (part / rhydromod);
+			*T += stably_normalised(_cross(rhydrodir, a1)) * part;
+
+			// THETA7; t7 = LRACOS (-rhydrodir * b3);
+			Ftmp -= stably_normalised(b3 + rhydrodir * cost7) * (hb_energy * f4t7D / (f4t7 * rhydromod));
+
+			// THETA 8; t8 = LRACOS (rhydrodir * a3);
+			part = -hb_energy * f4t8D / f4t8;
+			Ftmp += stably_normalised(a3 - rhydrodir * cost8) * (part / rhydromod);
+			*T += stably_normalised(_cross(rhydrodir, a3)) * part;
+
+			*T += _cross(ppos_base, Ftmp);
+
+			Ftmp.w = hb_energy;
+			*F += Ftmp;
+		}
+	}
+
+    return hb_energy;
+}
+
+__device__ c_number ipowf(c_number x, int n) {
+    c_number result = 1.0f;
+
+    while(n > 0) {
+        if(n & 1) result *= x;
+        x *= x;
+        n >>= 1;
+    }
+
+    return result;
+}
+
+__device__ inline c_number get_pair_contribution(const lt_coordination *coord, const c_number4 &r, const c_number4 &rhydro, const c_number4 &ppos, const c_number4 &a1, const c_number4 &a3, const c_number4 &qpos, const c_number4 &b1, const c_number4 &b3) {
+	c_number coord_contribution = 0.0f;
+
+	// Handle different coordination modes
+	switch(coord->coord_mode) {
+		case meta::CoordSettings::CoordMode::HB_ENERGY: {
+            number hb_energy = hb_interaction(r, rhydro, ppos, a1, a3, qpos, b1, b3, nullptr, nullptr, false);
+			coord_contribution = smooth_hb_contribution(coord->hb_energy_cutoff, coord->hb_transition_width, hb_energy);
+			break;
+		}
+		case meta::CoordSettings::CoordMode::SWITCHING_FUNCTION: {
+			c_number r_mod = _module(rhydro);
+			c_number x = (r_mod - coord->d0) / coord->r0; // fabsf because in single precision powf can give NaNs for negative bases, even if the result should be well-defined.
+			c_number xn = ipowf(x, coord->n);
+			c_number switching = 1.0f / (1.0f + xn);
+			coord_contribution = switching;
+			break;
+		}
+		case meta::CoordSettings::CoordMode::MIXED: {
+            number hb_energy = hb_interaction(r, rhydro, ppos, a1, a3, qpos, b1, b3, nullptr, nullptr, false);
+			c_number hb_contrib = smooth_hb_contribution(coord->hb_energy_cutoff, coord->hb_transition_width, hb_energy);
+
+			c_number r_mod = _module(rhydro);
+			c_number x = (r_mod - coord->d0) / coord->r0;
+			c_number xn = ipowf(x, coord->n);
+			c_number switching_contrib = 1.0f / (1.0f + xn);
+
+			coord_contribution = coord->mixed_weight * hb_contrib + (1.0f - coord->mixed_weight) * switching_contrib;
+			break;
+		}
+	}
+
+	return coord_contribution;
+}
+
+// Compute force and torque contribution from a single pair
+// Returns force and torque contributions that need to be multiplied by df_dcoord
+__device__ inline void get_pair_force_torque_contribution(const lt_coordination *coord, const c_number4 &r, 
+    const c_number4 &rhydro, const c_number4 &ppos, const c_number4 &a1, const c_number4 &a3, const c_number4 &qpos, 
+    const c_number4 &b1, const c_number4 &b3, c_number4 &force, c_number4 &torque) {
+
+    int p_idx = get_particle_index(ppos);
+    int q_idx = get_particle_index(qpos);
+    // Handle different coordination modes
+	switch(coord->coord_mode) {
+		case meta::CoordSettings::CoordMode::HB_ENERGY: {
+            number hb_energy = hb_interaction(r, rhydro, ppos, a1, a3, qpos, b1, b3, &force, &torque, true);
+			number dcoord_dhb_energy = der_smooth_hb_contribution(coord->hb_energy_cutoff, coord->hb_transition_width, hb_energy);
+            force *= dcoord_dhb_energy;
+            torque *= dcoord_dhb_energy;
+			break;
+		}
+		case meta::CoordSettings::CoordMode::SWITCHING_FUNCTION: {
+			c_number r_mod = _module(r);
+
+			c_number x = (r_mod - coord->d0) / coord->r0;
+            c_number xn = ipowf(x, coord->n);
+            c_number dcoord_dr = (coord->n / coord->r0) * ipowf(x, coord->n - 1) / (SQR(1.f + xn));
+
+            force = r / r_mod * dcoord_dr;
+            torque = _cross(POS_BASE * a1, force);
+			break;
+		}
+		case meta::CoordSettings::CoordMode::MIXED: {
+            number hb_energy = hb_interaction(r, rhydro, ppos, a1, a3, qpos, b1, b3, &force, &torque, true);
+			number dcoord_dhb_energy = der_smooth_hb_contribution(coord->hb_energy_cutoff, coord->hb_transition_width, hb_energy);
+
+            c_number4 hb_force_contribution = force * dcoord_dhb_energy;
+            c_number4 hb_torque_contribution = torque * dcoord_dhb_energy;
+
+			c_number r_mod = _module(rhydro);
+
+			c_number x = (r_mod - coord->d0) / coord->r0;
+            c_number xn = ipowf(x, coord->n);
+            c_number dcoord_dr = (coord->n / coord->r0) * ipowf(x, coord->n - 1) / (SQR(1.f + xn));
+
+            c_number4 switching_force_contribution = r / r_mod * dcoord_dr;
+            c_number4 switching_torque_contribution = _cross(POS_BASE * a1, switching_force_contribution);
+
+			force = coord->mixed_weight * hb_force_contribution + (1.f - coord->mixed_weight) * switching_force_contribution;
+            torque = coord->mixed_weight * hb_torque_contribution + (1.f - coord->mixed_weight) * switching_torque_contribution;
+			break;
+		}
+	}
+}
+
+__device__ inline c_number coordination(const lt_coordination *coord, c_number4 *poss, GPU_quat *orientations, CUDABox *box) {
+    number coordination = 0.f;
+    for(int i = 0; i < coord->n_pairs; i++) {
+        int2 pair = coord->pairs[i];
+        c_number4 pos1 = poss[pair.x];
+        c_number4 pos2 = poss[pair.y];
+
+        c_number4 a1, a2, a3, b1, b2, b3;
+        GPU_quat or1 = orientations[pair.x];
+        GPU_quat or2 = orientations[pair.y];
+        get_vectors_from_quat(or1, a1, a2, a3);
+        get_vectors_from_quat(or2, b1, b2, b3);
+
+        c_number4 r = box->minimum_image(pos1, pos2);
+        c_number4 rhydro = r + POS_BASE * (b1 - a1);
+
+        coordination += get_pair_contribution(coord, r, rhydro, pos1, a1, a3, pos2, b1, b3);
+    }
+    return coordination;
+}
+
+// Main function: compute force and torque for LTCoordination
+// This assumes you have access to particle data (positions, orientations) in your kernel
+__device__ inline void lt_coordination_force_torque(const lt_coordination *coord, int p_idx, c_number4 *poss, GPU_quat *orientations, 
+    const c_number4 &ppos, c_number4 &F, c_number4 &T, CUDABox *box) {
+	c_number coord_value = coordination(coord, poss, orientations, box);
+    c_number df_dcoord_value = get_x_force(coord_value, coord->d_coord, coord->coord_min, coord->potential_grid, coord->N_grid);
+
+    c_number4 qpos = poss[coord->idx_other];
+    c_number4 a1, a2, a3, b1, b2, b3;
+    GPU_quat por = orientations[p_idx];
+    get_vectors_from_quat(por, a1, a2, a3);
+    GPU_quat qor = orientations[coord->idx_other];
+    get_vectors_from_quat(qor, b1, b2, b3);
+
+    c_number4 r = box->minimum_image(ppos, qpos);
+    c_number4 rhydro = r + POS_BASE * (b1 - a1);
+
+    c_number4 force = make_c_number4(0.f, 0.f, 0.f, 0.f);
+    c_number4 torque = make_c_number4(0.f, 0.f, 0.f, 0.f);
+    get_pair_force_torque_contribution(coord, r, rhydro, ppos, a1, a3, qpos, b1, b3, force, torque);
+    F += df_dcoord_value * force;
+    T += df_dcoord_value * torque;
+}
+
+} // namespace cuda_meta
+
+#endif /* METAD_FORCES_H_ */

--- a/src/CUDA/Interactions/CUDATEPInteraction.cu
+++ b/src/CUDA/Interactions/CUDATEPInteraction.cu
@@ -200,7 +200,7 @@ __global__ void TEP_forces(c_number4 *poss, GPU_quat *orientations, c_number4 *f
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
+	c_number4 T = torques[IND];
 	c_number4 ppos = poss[IND];
 	LR_bonds pbonds = bonds[IND];
 

--- a/src/CUDA/Interactions/CUDA_DNA.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA.cuh
@@ -836,7 +836,7 @@ __global__ void dna_forces(const c_number4 __restrict__ *poss, const GPU_quat __
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
+	c_number4 T = torques[IND];
 	c_number4 ppos = poss[IND];
 	LR_bonds pbonds = bonds[IND];
 	bool p_is_end = (pbonds.n3 == P_INVALID || pbonds.n5 == P_INVALID);

--- a/src/CUDA/Interactions/CUDA_DNA3.cuh
+++ b/src/CUDA/Interactions/CUDA_DNA3.cuh
@@ -1005,7 +1005,7 @@ __global__ void DNA3_forces(const c_number4 __restrict__ *poss, const GPU_quat _
     if(IND >= MD_N[0]) return;
 
     c_number4 F = forces[IND];
-    c_number4 T = make_c_number4(0, 0, 0, 0);
+    c_number4 T = torques[IND];
     c_number4 ppos = poss[IND];
     LR_bonds pbonds = bonds[IND];
     neigh_types p_neighs(particle_types, pbonds);

--- a/src/CUDA/Interactions/CUDA_Patchy.cuh
+++ b/src/CUDA/Interactions/CUDA_Patchy.cuh
@@ -105,7 +105,7 @@ __global__ void patchy_forces(c_number4 *poss, GPU_quat *orientations, c_number4
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
+	c_number4 T = torques[IND];
 	c_number4 ppos = poss[IND];
 	GPU_quat po = orientations[IND];
 	c_number4 a1, a2, a3, b1, b2, b3;

--- a/src/CUDA/Interactions/CUDA_RNA.cuh
+++ b/src/CUDA/Interactions/CUDA_RNA.cuh
@@ -1052,7 +1052,7 @@ __global__ void rna_forces(const c_number4 __restrict__ *poss, const GPU_quat __
 	if(IND >= MD_N[0]) return;
 
 	c_number4 F = forces[IND];
-	c_number4 T = make_c_number4(0, 0, 0, 0);
+	c_number4 T = torques[IND];
 	c_number4 ppos = poss[IND];
 	LR_bonds pbonds = bonds[IND];
 	bool p_is_end = (pbonds.n3 == P_INVALID || pbonds.n5 == P_INVALID);

--- a/src/Forces/AlignmentField.cpp
+++ b/src/Forces/AlignmentField.cpp
@@ -68,7 +68,7 @@ std::tuple<std::vector<int>, std::string> AlignmentField::init(input_file &inp) 
 	return std::make_tuple(std::vector<int>{_particle}, description);
 }
 
-LR_vector AlignmentField::value(llint step, LR_vector &pos) {
+LR_vector AlignmentField::force(llint step, LR_vector &pos) {
 	throw oxDNAException("Not implemented... %s %s", __FILE__, __LINE__);
 }
 

--- a/src/Forces/AlignmentField.h
+++ b/src/Forces/AlignmentField.h
@@ -29,7 +29,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/AttractionPlane.cpp
+++ b/src/Forces/AttractionPlane.cpp
@@ -41,7 +41,7 @@ std::tuple<std::vector<int>, std::string> AttractionPlane::init(input_file &inp)
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector AttractionPlane::value(llint step, LR_vector &pos) {
+LR_vector AttractionPlane::force(llint step, LR_vector &pos) {
 	number distance_from_plane = this->_direction*pos + this->_position;
 
 	if(distance_from_plane >=  0.) {

--- a/src/Forces/AttractionPlane.h
+++ b/src/Forces/AttractionPlane.h
@@ -43,7 +43,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/BaseForce.cpp
+++ b/src/Forces/BaseForce.cpp
@@ -29,3 +29,11 @@ std::tuple<std::vector<int>, std::string> BaseForce::init(input_file &inp) {
 
 	return std::make_tuple(std::vector<int>(), "BaseForce");
 }
+
+LR_vector BaseForce::force(llint step, LR_vector &pos) {
+	return LR_vector(0., 0., 0.);
+}
+
+LR_vector BaseForce::torque(llint step, LR_vector &pos) {
+	return LR_vector(0., 0., 0.);
+}

--- a/src/Forces/BaseForce.h
+++ b/src/Forces/BaseForce.h
@@ -97,9 +97,17 @@ public:
 	 * @brief returns value of the force (a vector)
 	 *
 	 * @param step useful for forces that depend on time
-	 * @param pos position of the particle
+	 * @param pos absolute position of the particle
 	 */
-	virtual LR_vector value(llint step, LR_vector &pos) = 0;
+	virtual LR_vector force(llint step, LR_vector &pos);
+
+	/**
+	 * @brief returns value of the torque (a vector)
+	 *
+	 * @param step useful for forces that depend on time
+	 * @param pos absolute position of the particle
+	 */
+	virtual LR_vector torque(llint step, LR_vector &pos);
 
 	/**
 	 * @brief returns value of the potential associated to the force (a number)

--- a/src/Forces/COMForce.cpp
+++ b/src/Forces/COMForce.cpp
@@ -62,7 +62,7 @@ void COMForce::_compute_coms(llint step) {
 	}
 }
 
-LR_vector COMForce::value(llint step, LR_vector &pos) {
+LR_vector COMForce::force(llint step, LR_vector &pos) {
 	_compute_coms(step);
 	LR_vector dist = (_ref_com - _com);
 	number d_com = dist.module();

--- a/src/Forces/COMForce.h
+++ b/src/Forces/COMForce.h
@@ -47,7 +47,7 @@ public:
 
 	virtual std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/ConstantRateForce.cpp
+++ b/src/Forces/ConstantRateForce.cpp
@@ -51,7 +51,7 @@ std::tuple<std::vector<int>, std::string> ConstantRateForce::init(input_file &in
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector ConstantRateForce::value(llint step, LR_vector &pos) {
+LR_vector ConstantRateForce::force(llint step, LR_vector &pos) {
 	LR_vector dir = _direction;
 	if(dir_as_centre) {
 		dir -= pos;

--- a/src/Forces/ConstantRateForce.h
+++ b/src/Forces/ConstantRateForce.h
@@ -35,7 +35,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 
 };

--- a/src/Forces/ConstantRateTorque.cpp
+++ b/src/Forces/ConstantRateTorque.cpp
@@ -96,7 +96,7 @@ number ConstantRateTorque::potential(llint step, LR_vector &pos) {
 	return (number) (0.5 * _stiff * (dr * dr));
 }
 
-LR_vector ConstantRateTorque::value(llint step, LR_vector &pos) {
+LR_vector ConstantRateTorque::force(llint step, LR_vector &pos) {
 	//
 	// dobbiamo ruotare pos0 di (base + rate * t) radianti
 	// intorno all'asse passante per il centro.

--- a/src/Forces/ConstantRateTorque.cpp
+++ b/src/Forces/ConstantRateTorque.cpp
@@ -97,11 +97,8 @@ number ConstantRateTorque::potential(llint step, LR_vector &pos) {
 }
 
 LR_vector ConstantRateTorque::force(llint step, LR_vector &pos) {
-	//
-	// dobbiamo ruotare pos0 di (base + rate * t) radianti
-	// intorno all'asse passante per il centro.
-	// e quello ci da la pos della trappola;
-	//
+	// we rotate pos0 by (base + rate * t) radians around the axis passing 
+	// through the center, and that gives us the position of the trap
 	number t = (_F0 + _rate * (number) step);
 
 	number sintheta = sin(t);

--- a/src/Forces/ConstantRateTorque.h
+++ b/src/Forces/ConstantRateTorque.h
@@ -22,7 +22,7 @@ public:
 	void get_settings(input_file &);
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/ConstantTrap.cpp
+++ b/src/Forces/ConstantTrap.cpp
@@ -50,7 +50,7 @@ LR_vector ConstantTrap::_distance(LR_vector u, LR_vector v) {
 	}
 }
 
-LR_vector ConstantTrap::value(llint step, LR_vector &pos) {
+LR_vector ConstantTrap::force(llint step, LR_vector &pos) {
 	LR_vector dr = _distance(pos, CONFIG_INFO->box->get_abs_pos(_p_ptr)); // other - self
 	number sign = copysign(1., (double) (dr.module() - _r0));
 	return (_stiff * sign) * (dr / dr.module());

--- a/src/Forces/ConstantTrap.h
+++ b/src/Forces/ConstantTrap.h
@@ -27,7 +27,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 
 protected:

--- a/src/Forces/GenericCentralForce.cpp
+++ b/src/Forces/GenericCentralForce.cpp
@@ -179,7 +179,7 @@ std::tuple<std::vector<int>, std::string> GenericCentralForce::init(input_file &
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector GenericCentralForce::value(llint step, LR_vector &pos) {
+LR_vector GenericCentralForce::force(llint step, LR_vector &pos) {
 	LR_vector dir = center - pos;
 	number dist_sqr = dir.norm();
 	dir.normalize();

--- a/src/Forces/GenericCentralForce.h
+++ b/src/Forces/GenericCentralForce.h
@@ -54,7 +54,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 
 	LR_vector center;

--- a/src/Forces/HardWall.cpp
+++ b/src/Forces/HardWall.cpp
@@ -42,7 +42,7 @@ std::tuple<std::vector<int>, std::string> HardWall::init(input_file &inp) {
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector HardWall::value(llint step, LR_vector &pos) {
+LR_vector HardWall::force(llint step, LR_vector &pos) {
 	throw oxDNAException("HardWall can be used only in Monte Carlo simulations.");
 }
 

--- a/src/Forces/HardWall.h
+++ b/src/Forces/HardWall.h
@@ -43,7 +43,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/LJCone.cpp
+++ b/src/Forces/LJCone.cpp
@@ -66,7 +66,7 @@ std::tuple<std::vector<int>, std::string> LJCone::init(input_file &inp) {
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector LJCone::value(llint step, LR_vector &pos) {
+LR_vector LJCone::force(llint step, LR_vector &pos) {
 	LR_vector v_from_apex = pos - _pos0;
 
 	number d_along_axis = v_from_apex * _direction;

--- a/src/Forces/LJCone.h
+++ b/src/Forces/LJCone.h
@@ -31,7 +31,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/LJWall.cpp
+++ b/src/Forces/LJWall.cpp
@@ -56,7 +56,7 @@ std::tuple<std::vector<int>, std::string> LJWall::init(input_file &inp) {
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector LJWall::value(llint step, LR_vector &pos) {
+LR_vector LJWall::force(llint step, LR_vector &pos) {
 	number distance = _direction * pos + _position; // distance from the plane
 	number rel_distance = distance / _sigma; // distance from the plane in units of _sigma
 	if(rel_distance > _cutoff) return LR_vector(0., 0., 0.);

--- a/src/Forces/LJWall.h
+++ b/src/Forces/LJWall.h
@@ -56,7 +56,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/LowdimMovingTrap.cpp
+++ b/src/Forces/LowdimMovingTrap.cpp
@@ -56,7 +56,7 @@ std::tuple<std::vector<int>, std::string> LowdimMovingTrap::init(input_file &inp
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector LowdimMovingTrap::value(llint step, LR_vector &pos) {
+LR_vector LowdimMovingTrap::force(llint step, LR_vector &pos) {
 	LR_vector postrap;
 	number x, y, z;
 

--- a/src/Forces/LowdimMovingTrap.h
+++ b/src/Forces/LowdimMovingTrap.h
@@ -22,7 +22,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/Metadynamics/LT2DCOMTrap.cpp
+++ b/src/Forces/Metadynamics/LT2DCOMTrap.cpp
@@ -96,7 +96,7 @@ LR_vector LT2DCOMTrap::_distance(LR_vector u, LR_vector v) {
 		return v - u;
 }
 
-LR_vector LT2DCOMTrap::value(llint step, LR_vector &pos) {
+LR_vector LT2DCOMTrap::force(llint step, LR_vector &pos) {
 	LR_vector p1a_vec = meta::particle_list_com(_p1a_ptr, CONFIG_INFO->box);
 	LR_vector p2a_vec = meta::particle_list_com(_p2a_ptr, CONFIG_INFO->box);
 	LR_vector p1b_vec = meta::particle_list_com(_p1b_ptr, CONFIG_INFO->box);

--- a/src/Forces/Metadynamics/LT2DCOMTrap.h
+++ b/src/Forces/Metadynamics/LT2DCOMTrap.h
@@ -31,7 +31,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	LR_vector value(llint step, LR_vector &pos) override;
+	LR_vector force(llint step, LR_vector &pos) override;
 	number potential(llint step, LR_vector &pos) override;
 
 protected:

--- a/src/Forces/Metadynamics/LTAtanCOMTrap.cpp
+++ b/src/Forces/Metadynamics/LTAtanCOMTrap.cpp
@@ -98,7 +98,7 @@ LR_vector LTAtanCOMTrap::_distance(LR_vector u, LR_vector v) {
 		return v - u;
 }
 
-LR_vector LTAtanCOMTrap::value(llint step, LR_vector &pos) {
+LR_vector LTAtanCOMTrap::force(llint step, LR_vector &pos) {
 	LR_vector p1a_vec = meta::particle_list_com(_p1a_ptr, CONFIG_INFO->box);
 	LR_vector p2a_vec = meta::particle_list_com(_p2a_ptr, CONFIG_INFO->box);
 	LR_vector p1b_vec = meta::particle_list_com(_p1b_ptr, CONFIG_INFO->box);

--- a/src/Forces/Metadynamics/LTAtanCOMTrap.h
+++ b/src/Forces/Metadynamics/LTAtanCOMTrap.h
@@ -29,7 +29,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	LR_vector value(llint step, LR_vector &pos) override;
+	LR_vector force(llint step, LR_vector &pos) override;
 	number potential(llint step, LR_vector &pos) override;
 
 protected:

--- a/src/Forces/Metadynamics/LTCOMAngleTrap.cpp
+++ b/src/Forces/Metadynamics/LTCOMAngleTrap.cpp
@@ -59,7 +59,7 @@ LR_vector LTCOMAngleTrap::_distance(LR_vector u, LR_vector v) {
 		return v - u;
 }
 
-LR_vector LTCOMAngleTrap::value(llint step, LR_vector &pos) {
+LR_vector LTCOMAngleTrap::force(llint step, LR_vector &pos) {
 	LR_vector p1a_vec = meta::particle_list_com(_p1a_ptr, CONFIG_INFO->box);
 	LR_vector p2a_vec = meta::particle_list_com(_p2a_ptr, CONFIG_INFO->box);
 	LR_vector p3a_vec = meta::particle_list_com(_p3a_ptr, CONFIG_INFO->box);

--- a/src/Forces/Metadynamics/LTCOMAngleTrap.h
+++ b/src/Forces/Metadynamics/LTCOMAngleTrap.h
@@ -29,7 +29,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	LR_vector value(llint step, LR_vector &pos) override;
+	LR_vector force(llint step, LR_vector &pos) override;
 	number potential(llint step, LR_vector &pos) override;
 
 protected:

--- a/src/Forces/Metadynamics/LTCOMTrap.cpp
+++ b/src/Forces/Metadynamics/LTCOMTrap.cpp
@@ -55,7 +55,7 @@ LR_vector LTCOMTrap::_distance(LR_vector u, LR_vector v) {
 		return v - u;
 }
 
-LR_vector LTCOMTrap::value(llint step, LR_vector &pos) {
+LR_vector LTCOMTrap::force(llint step, LR_vector &pos) {
 	LR_vector p1a_vec = meta::particle_list_com(_p1a_ptr, CONFIG_INFO->box);
 	LR_vector p2a_vec = meta::particle_list_com(_p2a_ptr, CONFIG_INFO->box);
 

--- a/src/Forces/Metadynamics/LTCOMTrap.h
+++ b/src/Forces/Metadynamics/LTCOMTrap.h
@@ -26,7 +26,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	LR_vector value(llint step, LR_vector &pos) override;
+	LR_vector force(llint step, LR_vector &pos) override;
 	number potential(llint step, LR_vector &pos) override;
 
 protected:

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -112,14 +112,12 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 	}
 
 	else {
+        // note that this is not striclty only df/dcoord, since it also has a minux sign (hence the "get_x_force" name)
 		df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
 	}
 
     // Numerically compute dcoord/dr for any coordination definition
     number dcoord_dr = _dcoord_dr(pair);
-
-    LR_vector my_F = -sign * r_vec * (dcoord_dr / r);
-    printf("FORCE pair: %d %d, idx: %d, %g (%g %g %g)\n", pair.first->index, pair.second->index, _current_particle->index, dcoord_dr, my_F.x, my_F.y, my_F.z);
 
     // df / dr = df / dcoord * dcoord / dr_ij * dr_ij / dr
     return (number) sign * r_vec * (df_dcoord * dcoord_dr / r);
@@ -131,16 +129,11 @@ LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
 
     number df_dcoord = 0;
     if((ic_left >= 0) && (ic_left + 1 <= N_grid - 1)) {
+        // note that this is not striclty only df/dcoord, since it also has a minux sign (hence the "get_x_force" name)
         df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
     }
 
-    // Part 1: Torque from off-center force application
-    LR_vector F = force(step, pos);
-    LR_vector torque = _current_particle->int_centers[DNANucleotide::BASE].cross(F);
-
-    // Part 2: Direct torque from orientation-dependent coordination
-    LR_vector dcoord_dtheta = _dcoord_dtheta();
-    torque += dcoord_dtheta * df_dcoord;
+    LR_vector torque = _dcoord_dtheta() * df_dcoord;
 
     return torque;
 }
@@ -185,9 +178,7 @@ number LTCoordination::_dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair)
 }
 
 LR_vector LTCoordination::_dcoord_dtheta() {
-    static number delta = 1e-1;
-    static number sin_delta = sin(delta);
-    static number cos_delta = cos(delta);
+    static number delta = 1e-6;
     
     // Get the pair this particle belongs to
     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
@@ -197,52 +188,45 @@ LR_vector LTCoordination::_dcoord_dtheta() {
     
     LR_vector dcoord_dtheta(0, 0, 0);
     number contrib_plus, contrib_minus;
+
+    // here we use a central difference scheme, perturbing the orientation around each axis 
+    // *in the lab reference frame* in both directions and computing the contribution to the 
+    // coordination from the pair this particle belongs to
     
     // Central difference: Perturb rotation around x-axis (positive)
-    _current_particle->orientation.v2 = old_orient.v2 * cos_delta + old_orient.v3 * sin_delta;
-    _current_particle->orientation.v3 = -old_orient.v2 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(1, 0, 0), delta) * old_orient;
     _current_particle->orientationT = _current_particle->orientation.get_transpose();
     _current_particle->set_positions();
     contrib_plus = meta::get_pair_contribution(settings, pair);
     
     // Central difference: Perturb rotation around x-axis (negative)
-    _current_particle->orientation = old_orient;
-    _current_particle->orientation.v2 = old_orient.v2 * cos_delta - old_orient.v3 * sin_delta;
-    _current_particle->orientation.v3 = old_orient.v2 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(1, 0, 0), -delta) * old_orient;
     _current_particle->orientationT = _current_particle->orientation.get_transpose();
     _current_particle->set_positions();
     contrib_minus = meta::get_pair_contribution(settings, pair);
     dcoord_dtheta.x = (contrib_plus - contrib_minus) / (2.0 * delta);
     
     // Central difference: Perturb rotation around y-axis (positive)
-    _current_particle->orientation = old_orient;
-    _current_particle->orientation.v1 = old_orient.v1 * cos_delta - old_orient.v3 * sin_delta;
-    _current_particle->orientation.v3 = old_orient.v1 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 1, 0), delta) * old_orient;
     _current_particle->orientationT = _current_particle->orientation.get_transpose();
     _current_particle->set_positions();
     contrib_plus = meta::get_pair_contribution(settings, pair);
     
     // Central difference: Perturb rotation around y-axis (negative)
-    _current_particle->orientation = old_orient;
-    _current_particle->orientation.v1 = old_orient.v1 * cos_delta + old_orient.v3 * sin_delta;
-    _current_particle->orientation.v3 = -old_orient.v1 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 1, 0), -delta) * old_orient;
     _current_particle->orientationT = _current_particle->orientation.get_transpose();
     _current_particle->set_positions();
     contrib_minus = meta::get_pair_contribution(settings, pair);
     dcoord_dtheta.y = (contrib_plus - contrib_minus) / (2.0 * delta);
     
     // Central difference: Perturb rotation around z-axis (positive)
-    _current_particle->orientation = old_orient;
-    _current_particle->orientation.v1 = old_orient.v1 * cos_delta + old_orient.v2 * sin_delta;
-    _current_particle->orientation.v2 = -old_orient.v1 * sin_delta + old_orient.v2 * cos_delta;
+    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 0, 1), delta) * old_orient;
     _current_particle->orientationT = _current_particle->orientation.get_transpose();
     _current_particle->set_positions();
     contrib_plus = meta::get_pair_contribution(settings, pair);
     
     // Central difference: Perturb rotation around z-axis (negative)
-    _current_particle->orientation = old_orient;
-    _current_particle->orientation.v1 = old_orient.v1 * cos_delta - old_orient.v2 * sin_delta;
-    _current_particle->orientation.v2 = old_orient.v1 * sin_delta + old_orient.v2 * cos_delta;
+    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 0, 1), -delta) * old_orient;
     _current_particle->orientationT = _current_particle->orientation.get_transpose();
     _current_particle->set_positions();
     contrib_minus = meta::get_pair_contribution(settings, pair);
@@ -252,14 +236,12 @@ LR_vector LTCoordination::_dcoord_dtheta() {
     _current_particle->orientation = old_orient;
     _current_particle->orientationT = old_orientT;
     _current_particle->set_positions();
-
-    printf("TORQUE pair: %d %d, idx: %d, %g %g %g\n", pair.first->index, pair.second->index, _current_particle->index, dcoord_dtheta.x, dcoord_dtheta.y, dcoord_dtheta.z);
     
     return dcoord_dtheta;
 }
 
 // LR_vector LTCoordination::_dcoord_dtheta() {
-//     static number delta = 1e-1;
+//     static number delta = 1e-2;
 //     static number sin_delta = sin(delta);
 //     static number cos_delta = cos(delta);
     

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -66,7 +66,7 @@ std::tuple<std::vector<int>, std::string> LTCoordination::init(input_file &inp) 
     // here we look for duplicates
     auto it = std::adjacent_find(p_indices.begin(), p_indices.end());
     if(it != p_indices.end()) {
-        throw oxDNAException("LTCoordination: duplicate particle index found in the op_file: %d", *it);
+        throw oxDNAException("LTCoordination: duplicate particle index found in the op_file: %d. LTCoordination assumes each particle appears only once", *it);
     }
 
     settings.get_settings(inp);
@@ -96,7 +96,6 @@ std::tuple<std::vector<int>, std::string> LTCoordination::init(input_file &inp) 
 
 LR_vector LTCoordination::force(llint step, LR_vector &pos) {
     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
-    int sign = (pair.first == _current_particle) ? -1 : 1;
 
     number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max); // ensure we are within the grid limits
     int ic_left = std::floor((coord - coord_min) / d_coord);
@@ -114,7 +113,16 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 	}
 
     LR_vector dcoord_dpos = _dcoord_dpos(pair);
-    return dcoord_dpos * (df_dcoord * sign);
+
+    // DNANucleotide p = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.first : pair.second);
+    // DNANucleotide q = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.second : pair.first);
+    // p.force = LR_vector();
+    // q.force = LR_vector();
+    // CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, &p, &q, true, true);
+    // printf("FORCE %d\n\t%g %g %g\n", p.index, p.force.x, p.force.y, p.force.z);
+    // printf("\t%g %g %g\n", dcoord_dpos.x, dcoord_dpos.y, dcoord_dpos.z);
+
+    return dcoord_dpos * df_dcoord;
 }
 
 LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
@@ -127,9 +135,19 @@ LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
         df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
     }
 
-    LR_vector torque = _dcoord_dtheta() * df_dcoord;
+    LR_vector dcoord_dtheta = _dcoord_dtheta();
 
-    return torque;
+    // auto pair = all_pairs[particle_to_pair_index[_current_particle]];
+    // DNANucleotide p = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.first : pair.second);
+    // DNANucleotide q = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.second : pair.first);
+    // p.force = LR_vector();
+    // q.force = LR_vector();
+    // LR_vector pref_torque = _current_particle->orientationT * dcoord_dtheta;
+    // CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, &p, &q, true, true);
+    // printf("TORQUE %d\n\t%g %g %g\n", p.index, p.torque.x, p.torque.y, p.torque.z);
+    // printf("\t%g %g %g\n", pref_torque.x, pref_torque.y, pref_torque.z);
+
+    return dcoord_dtheta * df_dcoord;
 }
 
 number LTCoordination::potential(llint step, LR_vector &pos) {
@@ -143,20 +161,19 @@ number LTCoordination::potential(llint step, LR_vector &pos) {
 	}
 	else {
 		my_potential = meta::interpolate_potential(coord, d_coord, coord_min, potential_grid);
+        // printf("coord = %lf, index = %d, potential = %lf\n", coord, ic_left, my_potential);
 	}
 
     return my_potential / (2.0 * all_pairs.size()); // divide by 2 to avoid double counting
 }
 
 LR_vector LTCoordination::_dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &pair) {
-    static number delta = 1e-6;
     LR_vector old_pos = _current_particle->pos;
-    LR_vector grad(0, 0, 0);
-    int sign = (pair.first == _current_particle) ? -1 : 1;
+    LR_vector grad;
 
     for(int i = 0; i < 3; i++) {
-        LR_vector shift(0, 0, 0);
-        shift[i] = delta;
+        LR_vector shift;
+        shift[i] = delta_F;
 
         _current_particle->pos = old_pos + shift;
         number plus = meta::get_pair_contribution(settings, pair);
@@ -164,15 +181,13 @@ LR_vector LTCoordination::_dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &
         _current_particle->pos = old_pos - shift;
         number minus = meta::get_pair_contribution(settings, pair);
 
-        grad[i] = sign * (plus - minus) / (2.0 * delta);
+        grad[i] =  (plus - minus) / (2.0 * delta_F);
     }
     _current_particle->pos = old_pos;
     return grad;
 }
 
 number LTCoordination::_dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair) {
-    static number delta = 1e-6;
-    
     LR_vector r_vec = meta::distance(pair);
     number r = r_vec.module();
 
@@ -182,15 +197,15 @@ number LTCoordination::_dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair)
     int sign = (pair.first == _current_particle) ? 1 : -1;
     
     // Central difference - only compute contribution from this pair (particle belongs to single pair)
-    _current_particle->pos = old_pos + dr_hat * (sign * delta);
+    _current_particle->pos = old_pos + dr_hat * (sign * delta_F);
     number contrib_plus = meta::get_pair_contribution(settings, pair);
     
-    _current_particle->pos = old_pos - dr_hat * (sign * delta);
+    _current_particle->pos = old_pos - dr_hat * (sign * delta_F);
     number contrib_minus = meta::get_pair_contribution(settings, pair);
     
     _current_particle->pos = old_pos;  // Restore
     
-    return (contrib_plus - contrib_minus) / (2.0 * delta);
+    return (contrib_plus - contrib_minus) / (2.0 * delta_F);
 }
 
 LR_vector LTCoordination::_dcoord_dtheta() {
@@ -255,50 +270,3 @@ LR_vector LTCoordination::_dcoord_dtheta() {
     
     return dcoord_dtheta;
 }
-
-// LR_vector LTCoordination::_dcoord_dtheta() {
-//     static number delta = 1e-2;
-//     static number sin_delta = sin(delta);
-//     static number cos_delta = cos(delta);
-    
-//     // Get the pair this particle belongs to
-//     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
-//     number contrib_0 = meta::get_pair_contribution(settings, pair);
-    
-//     LR_matrix old_orient = _current_particle->orientation;
-//     LR_matrix old_orientT = _current_particle->orientationT;
-    
-//     LR_vector dcoord_dtheta(0, 0, 0);
-    
-//     // Perturb rotation around x-axis
-//     _current_particle->orientation.v2 = old_orient.v2 * cos_delta + old_orient.v3 * sin_delta;
-//     _current_particle->orientation.v3 = -old_orient.v2 * sin_delta + old_orient.v3 * cos_delta;
-//     _current_particle->orientationT = _current_particle->orientation.get_transpose();
-//     _current_particle->set_positions();
-//     dcoord_dtheta.x = (meta::get_pair_contribution(settings, pair) - contrib_0) / delta;
-    
-//     // Perturb rotation around y-axis
-//     _current_particle->orientation = old_orient;
-//     _current_particle->orientation.v1 = old_orient.v1 * cos_delta - old_orient.v3 * sin_delta;
-//     _current_particle->orientation.v3 = old_orient.v1 * sin_delta + old_orient.v3 * cos_delta;
-//     _current_particle->orientationT = _current_particle->orientation.get_transpose();
-//     _current_particle->set_positions();
-//     dcoord_dtheta.y = (meta::get_pair_contribution(settings, pair) - contrib_0) / delta;
-    
-//     // Perturb rotation around z-axis
-//     _current_particle->orientation = old_orient;
-//     _current_particle->orientation.v1 = old_orient.v1 * cos_delta + old_orient.v2 * sin_delta;
-//     _current_particle->orientation.v2 = -old_orient.v1 * sin_delta + old_orient.v2 * cos_delta;
-//     _current_particle->orientationT = _current_particle->orientation.get_transpose();
-//     _current_particle->set_positions();
-//     dcoord_dtheta.z = (meta::get_pair_contribution(settings, pair) - contrib_0) / delta;
-    
-//     // Restore original orientation
-//     _current_particle->orientation = old_orient;
-//     _current_particle->orientationT = old_orientT;
-//     _current_particle->set_positions();
-
-//     printf("TORQUE pair: %d %d, idx: %d, %g %g %g\n", pair.first->index, pair.second->index, _current_particle->index, dcoord_dtheta.x, dcoord_dtheta.y, dcoord_dtheta.z);
-    
-//     return dcoord_dtheta;
-// }

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -99,7 +99,7 @@ std::tuple<std::vector<int>, std::string> LTCoordination::init(input_file &inp) 
     return std::make_tuple(p_indices, msg);
 }
 
-LR_vector LTCoordination::value(llint step, LR_vector &pos) {
+LR_vector LTCoordination::force(llint step, LR_vector &pos) {
     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
     int sign = (pair.first == _current_particle) ? -1 : 1;
 

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -93,8 +93,8 @@ std::tuple<std::vector<int>, std::string> LTCoordination::init(input_file &inp) 
     // initialise rotation matrices for torque calculation
     LR_vector axes[3] = {LR_vector(1, 0, 0), LR_vector(0, 1, 0), LR_vector(0, 0, 1)};
     for(int i = 0; i < 3; i++) {
-        _rot_matrices[i][0] = Utils::get_rotation_matrix_from_axis_angle(axes[i], delta_T);
-        _rot_matrices[i][1] = Utils::get_rotation_matrix_from_axis_angle(axes[i], -delta_T);;
+        _rot_matrices[i][0] = Utils::get_rotation_matrix_from_axis_angle(axes[i], _delta_T);
+        _rot_matrices[i][1] = Utils::get_rotation_matrix_from_axis_angle(axes[i], -_delta_T);;
     }
 
     std::string msg = Utils::sformat("LTCoordination force (d0 = %lf, r0 = %lf, n = %d, coord_min = %lf, coord_max = %lf, N_grid = %d)", settings.d0, settings.r0, settings.n, coord_min, coord_max, N_grid);
@@ -117,12 +117,8 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 		df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
 	}
 
-    // std::cout << "F OLD " << _dcoord_dpos() << std::endl;
-    // auto pair = all_pairs[particle_to_pair_index[_current_particle]];
     auto force_torque = meta::get_pair_force_torque_contribution(settings, all_pairs[particle_to_pair_index[_current_particle]], _current_particle);
     LR_vector dcoord_dpos = force_torque.first;
-    // auto F = dcoord_dpos;
-    // std::cout << "F NEW " << F << std::endl;
 
     return dcoord_dpos * df_dcoord;
 }
@@ -137,11 +133,8 @@ LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
         df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
     }
 
-    // std::cout << "T OLD " << _dcoord_dtheta() << std::endl;
     auto force_torque = meta::get_pair_force_torque_contribution(settings, all_pairs[particle_to_pair_index[_current_particle]], _current_particle);
     LR_vector dcoord_dtheta = force_torque.second;
-    // auto torque = dcoord_dtheta;
-    // std::cout << "T NEW " << torque << std::endl;
 
     return dcoord_dtheta * df_dcoord;
 }
@@ -169,7 +162,7 @@ LR_vector LTCoordination::_dcoord_dpos() {
 
     for(int i = 0; i < 3; i++) {
         LR_vector shift;
-        shift[i] = delta_F;
+        shift[i] = _delta_F;
 
         _current_particle->pos = old_pos + shift;
         number plus = meta::get_pair_contribution(settings, pair);
@@ -177,7 +170,7 @@ LR_vector LTCoordination::_dcoord_dpos() {
         _current_particle->pos = old_pos - shift;
         number minus = meta::get_pair_contribution(settings, pair);
 
-        grad[i] = (plus - minus) / (2.0 * delta_F);
+        grad[i] = (plus - minus) / (2.0 * _delta_F);
     }
     _current_particle->pos = old_pos;
     return grad;
@@ -209,7 +202,7 @@ LR_vector LTCoordination::_dcoord_dtheta() {
         _current_particle->set_positions();
         contrib_minus = meta::get_pair_contribution(settings, pair);
 
-        dcoord_dtheta[i] = (contrib_plus - contrib_minus) / (2.0 * delta_T);
+        dcoord_dtheta[i] = (contrib_plus - contrib_minus) / (2.0 * _delta_T);
     }
     
     // Restore original orientation

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -10,11 +10,13 @@
 #include "meta_utils.h"
 #include "../../Utilities/OrderParameters.h"
 #include "../../Utilities/Utils.h"
+#include "../../Interactions/BaseInteraction.h"
+#include "../../Interactions/DNA2Interaction.h"
 
 #include <iostream>
 
 LTCoordination::LTCoordination() {
-
+    
 }
 
 LTCoordination::~LTCoordination() {
@@ -67,13 +69,7 @@ std::tuple<std::vector<int>, std::string> LTCoordination::init(input_file &inp) 
         throw oxDNAException("LTCoordination: duplicate particle index found in the op_file: %d", *it);
     }
 
-    getInputNumber(&inp, "d0", &d0, 0);
-	getInputNumber(&inp, "r0", &r0, 0);
-    getInputInt(&inp, "n", &n, 0);
-
-    if(n % 2 != 0) {
-        throw oxDNAException("LTCoordination: exponent n must be an even integer");
-    }
+    settings.get_settings(inp);
 
     // build the grid
     if(getInputNumber(&inp, "coord_min", &coord_min, 0) == KEY_NOT_FOUND) {
@@ -94,8 +90,7 @@ std::tuple<std::vector<int>, std::string> LTCoordination::init(input_file &inp) 
         throw oxDNAException("LTCoordination: potential_grid size (%u) != N_grid (%d)", potential_grid.size(), N_grid);
     }
 
-    std::string msg = Utils::sformat("LTCoordination force (d0 = %lf, r0 = %lf, n = %d, coord_min = %lf, coord_max = %lf, N_grid = %d)", 
-        d0, r0, n, coord_min, coord_max, N_grid);
+    std::string msg = Utils::sformat("LTCoordination force (d0 = %lf, r0 = %lf, n = %d, coord_min = %lf, coord_max = %lf, N_grid = %d)", settings.d0, settings.r0, settings.n, coord_min, coord_max, N_grid);
     return std::make_tuple(p_indices, msg);
 }
 
@@ -103,13 +98,10 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
     int sign = (pair.first == _current_particle) ? -1 : 1;
 
-    LR_vector r_vec = _distance(pair);
+    LR_vector r_vec = meta::distance(pair);
     number r = r_vec.module();
-    double x = (r - d0) / r0;
-    double xn = std::pow(x, n);
-    double dcoord_dr = -(n / r0) * std::pow(x, n - 1) / (SQR(1.0 + xn));
 
-    number coord = Utils::clamp(_coordination(), coord_min, coord_max); // ensure we are within the grid limits
+    number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max); // ensure we are within the grid limits
     int ic_left = std::floor((coord - coord_min) / d_coord);
 	int ic_right = ic_left + 1;
 
@@ -123,19 +115,38 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 		df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
 	}
 
+    // Numerically compute dcoord/dr for any coordination definition
+    number dcoord_dr = _dcoord_dr(pair);
+
+    LR_vector my_F = -sign * r_vec * (dcoord_dr / r);
+    printf("FORCE pair: %d %d, idx: %d, %g (%g %g %g)\n", pair.first->index, pair.second->index, _current_particle->index, dcoord_dr, my_F.x, my_F.y, my_F.z);
+
     // df / dr = df / dcoord * dcoord / dr_ij * dr_ij / dr
     return (number) sign * r_vec * (df_dcoord * dcoord_dr / r);
 }
 
 LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
+    number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max);
+    int ic_left = std::floor((coord - coord_min) / d_coord);
+
+    number df_dcoord = 0;
+    if((ic_left >= 0) && (ic_left + 1 <= N_grid - 1)) {
+        df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
+    }
+
+    // Part 1: Torque from off-center force application
     LR_vector F = force(step, pos);
     LR_vector torque = _current_particle->int_centers[DNANucleotide::BASE].cross(F);
+
+    // Part 2: Direct torque from orientation-dependent coordination
+    LR_vector dcoord_dtheta = _dcoord_dtheta();
+    torque += dcoord_dtheta * df_dcoord;
 
     return torque;
 }
 
 number LTCoordination::potential(llint step, LR_vector &pos) {
-    number coord = Utils::clamp(_coordination(), coord_min, coord_max); // ensure we are within the grid limits
+    number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max); // ensure we are within the grid limits
     int ic_left = std::floor((coord - coord_min) / d_coord);
 	int ic_right = ic_left + 1;
 
@@ -150,19 +161,146 @@ number LTCoordination::potential(llint step, LR_vector &pos) {
     return my_potential / (2.0 * all_pairs.size()); // divide by 2 to avoid double counting
 }
 
-LR_vector LTCoordination::_distance(std::pair<BaseParticle *, BaseParticle *> &pair) {
-    LR_vector p_base = pair.first->pos + pair.first->int_centers[DNANucleotide::BASE];
-    LR_vector q_base = pair.second->pos + pair.second->int_centers[DNANucleotide::BASE];
+number LTCoordination::_dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair) {
+    static number delta = 1e-6;
+    
+    LR_vector r_vec = meta::distance(pair);
+    number r = r_vec.module();
 
-    return CONFIG_INFO->box->min_image(p_base, q_base);
+    LR_vector dr_hat = r_vec / r;
+    LR_vector old_pos = _current_particle->pos;
+    // Determine the sign based on whether the current particle is the first or second in the pair
+    int sign = (pair.first == _current_particle) ? 1 : -1;
+    
+    // Central difference - only compute contribution from this pair (particle belongs to single pair)
+    _current_particle->pos = old_pos + dr_hat * (sign * delta);
+    number contrib_plus = meta::get_pair_contribution(settings, pair);
+    
+    _current_particle->pos = old_pos - dr_hat * (sign * delta);
+    number contrib_minus = meta::get_pair_contribution(settings, pair);
+    
+    _current_particle->pos = old_pos;  // Restore
+    
+    return (contrib_plus - contrib_minus) / (2.0 * delta);
 }
 
-double LTCoordination::_coordination() {
-    number coordination = 0.0;
-    for(auto &pair : all_pairs) {
-        number r = _distance(pair).module();
-        coordination += 1.0 / (1.0 + std::pow((r - d0) / r0, n));
-    }
+LR_vector LTCoordination::_dcoord_dtheta() {
+    static number delta = 1e-1;
+    static number sin_delta = sin(delta);
+    static number cos_delta = cos(delta);
+    
+    // Get the pair this particle belongs to
+    auto pair = all_pairs[particle_to_pair_index[_current_particle]];
+    
+    LR_matrix old_orient = _current_particle->orientation;
+    LR_matrix old_orientT = _current_particle->orientationT;
+    
+    LR_vector dcoord_dtheta(0, 0, 0);
+    number contrib_plus, contrib_minus;
+    
+    // Central difference: Perturb rotation around x-axis (positive)
+    _current_particle->orientation.v2 = old_orient.v2 * cos_delta + old_orient.v3 * sin_delta;
+    _current_particle->orientation.v3 = -old_orient.v2 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientationT = _current_particle->orientation.get_transpose();
+    _current_particle->set_positions();
+    contrib_plus = meta::get_pair_contribution(settings, pair);
+    
+    // Central difference: Perturb rotation around x-axis (negative)
+    _current_particle->orientation = old_orient;
+    _current_particle->orientation.v2 = old_orient.v2 * cos_delta - old_orient.v3 * sin_delta;
+    _current_particle->orientation.v3 = old_orient.v2 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientationT = _current_particle->orientation.get_transpose();
+    _current_particle->set_positions();
+    contrib_minus = meta::get_pair_contribution(settings, pair);
+    dcoord_dtheta.x = (contrib_plus - contrib_minus) / (2.0 * delta);
+    
+    // Central difference: Perturb rotation around y-axis (positive)
+    _current_particle->orientation = old_orient;
+    _current_particle->orientation.v1 = old_orient.v1 * cos_delta - old_orient.v3 * sin_delta;
+    _current_particle->orientation.v3 = old_orient.v1 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientationT = _current_particle->orientation.get_transpose();
+    _current_particle->set_positions();
+    contrib_plus = meta::get_pair_contribution(settings, pair);
+    
+    // Central difference: Perturb rotation around y-axis (negative)
+    _current_particle->orientation = old_orient;
+    _current_particle->orientation.v1 = old_orient.v1 * cos_delta + old_orient.v3 * sin_delta;
+    _current_particle->orientation.v3 = -old_orient.v1 * sin_delta + old_orient.v3 * cos_delta;
+    _current_particle->orientationT = _current_particle->orientation.get_transpose();
+    _current_particle->set_positions();
+    contrib_minus = meta::get_pair_contribution(settings, pair);
+    dcoord_dtheta.y = (contrib_plus - contrib_minus) / (2.0 * delta);
+    
+    // Central difference: Perturb rotation around z-axis (positive)
+    _current_particle->orientation = old_orient;
+    _current_particle->orientation.v1 = old_orient.v1 * cos_delta + old_orient.v2 * sin_delta;
+    _current_particle->orientation.v2 = -old_orient.v1 * sin_delta + old_orient.v2 * cos_delta;
+    _current_particle->orientationT = _current_particle->orientation.get_transpose();
+    _current_particle->set_positions();
+    contrib_plus = meta::get_pair_contribution(settings, pair);
+    
+    // Central difference: Perturb rotation around z-axis (negative)
+    _current_particle->orientation = old_orient;
+    _current_particle->orientation.v1 = old_orient.v1 * cos_delta - old_orient.v2 * sin_delta;
+    _current_particle->orientation.v2 = old_orient.v1 * sin_delta + old_orient.v2 * cos_delta;
+    _current_particle->orientationT = _current_particle->orientation.get_transpose();
+    _current_particle->set_positions();
+    contrib_minus = meta::get_pair_contribution(settings, pair);
+    dcoord_dtheta.z = (contrib_plus - contrib_minus) / (2.0 * delta);
+    
+    // Restore original orientation
+    _current_particle->orientation = old_orient;
+    _current_particle->orientationT = old_orientT;
+    _current_particle->set_positions();
 
-    return coordination;
+    printf("TORQUE pair: %d %d, idx: %d, %g %g %g\n", pair.first->index, pair.second->index, _current_particle->index, dcoord_dtheta.x, dcoord_dtheta.y, dcoord_dtheta.z);
+    
+    return dcoord_dtheta;
 }
+
+// LR_vector LTCoordination::_dcoord_dtheta() {
+//     static number delta = 1e-1;
+//     static number sin_delta = sin(delta);
+//     static number cos_delta = cos(delta);
+    
+//     // Get the pair this particle belongs to
+//     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
+//     number contrib_0 = meta::get_pair_contribution(settings, pair);
+    
+//     LR_matrix old_orient = _current_particle->orientation;
+//     LR_matrix old_orientT = _current_particle->orientationT;
+    
+//     LR_vector dcoord_dtheta(0, 0, 0);
+    
+//     // Perturb rotation around x-axis
+//     _current_particle->orientation.v2 = old_orient.v2 * cos_delta + old_orient.v3 * sin_delta;
+//     _current_particle->orientation.v3 = -old_orient.v2 * sin_delta + old_orient.v3 * cos_delta;
+//     _current_particle->orientationT = _current_particle->orientation.get_transpose();
+//     _current_particle->set_positions();
+//     dcoord_dtheta.x = (meta::get_pair_contribution(settings, pair) - contrib_0) / delta;
+    
+//     // Perturb rotation around y-axis
+//     _current_particle->orientation = old_orient;
+//     _current_particle->orientation.v1 = old_orient.v1 * cos_delta - old_orient.v3 * sin_delta;
+//     _current_particle->orientation.v3 = old_orient.v1 * sin_delta + old_orient.v3 * cos_delta;
+//     _current_particle->orientationT = _current_particle->orientation.get_transpose();
+//     _current_particle->set_positions();
+//     dcoord_dtheta.y = (meta::get_pair_contribution(settings, pair) - contrib_0) / delta;
+    
+//     // Perturb rotation around z-axis
+//     _current_particle->orientation = old_orient;
+//     _current_particle->orientation.v1 = old_orient.v1 * cos_delta + old_orient.v2 * sin_delta;
+//     _current_particle->orientation.v2 = -old_orient.v1 * sin_delta + old_orient.v2 * cos_delta;
+//     _current_particle->orientationT = _current_particle->orientation.get_transpose();
+//     _current_particle->set_positions();
+//     dcoord_dtheta.z = (meta::get_pair_contribution(settings, pair) - contrib_0) / delta;
+    
+//     // Restore original orientation
+//     _current_particle->orientation = old_orient;
+//     _current_particle->orientationT = old_orientT;
+//     _current_particle->set_positions();
+
+//     printf("TORQUE pair: %d %d, idx: %d, %g %g %g\n", pair.first->index, pair.second->index, _current_particle->index, dcoord_dtheta.x, dcoord_dtheta.y, dcoord_dtheta.z);
+    
+//     return dcoord_dtheta;
+// }

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -98,9 +98,6 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
     int sign = (pair.first == _current_particle) ? -1 : 1;
 
-    LR_vector r_vec = meta::distance(pair);
-    number r = r_vec.module();
-
     number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max); // ensure we are within the grid limits
     int ic_left = std::floor((coord - coord_min) / d_coord);
 	int ic_right = ic_left + 1;
@@ -116,11 +113,8 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 		df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
 	}
 
-    // Numerically compute dcoord/dr for any coordination definition
-    number dcoord_dr = _dcoord_dr(pair);
-
-    // df / dr = df / dcoord * dcoord / dr_ij * dr_ij / dr
-    return (number) sign * r_vec * (df_dcoord * dcoord_dr / r);
+    LR_vector dcoord_dpos = _dcoord_dpos(pair);
+    return dcoord_dpos * (df_dcoord * sign);
 }
 
 LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
@@ -152,6 +146,28 @@ number LTCoordination::potential(llint step, LR_vector &pos) {
 	}
 
     return my_potential / (2.0 * all_pairs.size()); // divide by 2 to avoid double counting
+}
+
+LR_vector LTCoordination::_dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &pair) {
+    static number delta = 1e-6;
+    LR_vector old_pos = _current_particle->pos;
+    LR_vector grad(0, 0, 0);
+    int sign = (pair.first == _current_particle) ? -1 : 1;
+
+    for(int i = 0; i < 3; i++) {
+        LR_vector shift(0, 0, 0);
+        shift[i] = delta;
+
+        _current_particle->pos = old_pos + shift;
+        number plus = meta::get_pair_contribution(settings, pair);
+
+        _current_particle->pos = old_pos - shift;
+        number minus = meta::get_pair_contribution(settings, pair);
+
+        grad[i] = sign * (plus - minus) / (2.0 * delta);
+    }
+    _current_particle->pos = old_pos;
+    return grad;
 }
 
 number LTCoordination::_dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair) {

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -90,14 +90,19 @@ std::tuple<std::vector<int>, std::string> LTCoordination::init(input_file &inp) 
         throw oxDNAException("LTCoordination: potential_grid size (%u) != N_grid (%d)", potential_grid.size(), N_grid);
     }
 
+    // initialise rotation matrices for torque calculation
+    LR_vector axes[3] = {LR_vector(1, 0, 0), LR_vector(0, 1, 0), LR_vector(0, 0, 1)};
+    for(int i = 0; i < 3; i++) {
+        _rot_matrices[i][0] = Utils::get_rotation_matrix_from_axis_angle(axes[i], delta_T);
+        _rot_matrices[i][1] = Utils::get_rotation_matrix_from_axis_angle(axes[i], -delta_T);;
+    }
+
     std::string msg = Utils::sformat("LTCoordination force (d0 = %lf, r0 = %lf, n = %d, coord_min = %lf, coord_max = %lf, N_grid = %d)", settings.d0, settings.r0, settings.n, coord_min, coord_max, N_grid);
     return std::make_tuple(p_indices, msg);
 }
 
 LR_vector LTCoordination::force(llint step, LR_vector &pos) {
-    auto pair = all_pairs[particle_to_pair_index[_current_particle]];
-
-    number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max); // ensure we are within the grid limits
+    number coord = _coordination(step);
     int ic_left = std::floor((coord - coord_min) / d_coord);
 	int ic_right = ic_left + 1;
 
@@ -112,7 +117,7 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 		df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
 	}
 
-    LR_vector dcoord_dpos = _dcoord_dpos(pair);
+    LR_vector dcoord_dpos = _dcoord_dpos();
 
     // DNANucleotide p = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.first : pair.second);
     // DNANucleotide q = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.second : pair.first);
@@ -126,7 +131,7 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 }
 
 LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
-    number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max);
+    number coord = _coordination(step);
     int ic_left = std::floor((coord - coord_min) / d_coord);
 
     number df_dcoord = 0;
@@ -151,7 +156,7 @@ LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
 }
 
 number LTCoordination::potential(llint step, LR_vector &pos) {
-    number coord = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max); // ensure we are within the grid limits
+    number coord = _coordination(step);
     int ic_left = std::floor((coord - coord_min) / d_coord);
 	int ic_right = ic_left + 1;
 
@@ -167,7 +172,8 @@ number LTCoordination::potential(llint step, LR_vector &pos) {
     return my_potential / (2.0 * all_pairs.size()); // divide by 2 to avoid double counting
 }
 
-LR_vector LTCoordination::_dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &pair) {
+LR_vector LTCoordination::_dcoord_dpos() {
+    auto pair = all_pairs[particle_to_pair_index[_current_particle]];
     LR_vector old_pos = _current_particle->pos;
     LR_vector grad;
 
@@ -181,36 +187,13 @@ LR_vector LTCoordination::_dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &
         _current_particle->pos = old_pos - shift;
         number minus = meta::get_pair_contribution(settings, pair);
 
-        grad[i] =  (plus - minus) / (2.0 * delta_F);
+        grad[i] = (plus - minus) / (2.0 * delta_F);
     }
     _current_particle->pos = old_pos;
     return grad;
 }
 
-number LTCoordination::_dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair) {
-    LR_vector r_vec = meta::distance(pair);
-    number r = r_vec.module();
-
-    LR_vector dr_hat = r_vec / r;
-    LR_vector old_pos = _current_particle->pos;
-    // Determine the sign based on whether the current particle is the first or second in the pair
-    int sign = (pair.first == _current_particle) ? 1 : -1;
-    
-    // Central difference - only compute contribution from this pair (particle belongs to single pair)
-    _current_particle->pos = old_pos + dr_hat * (sign * delta_F);
-    number contrib_plus = meta::get_pair_contribution(settings, pair);
-    
-    _current_particle->pos = old_pos - dr_hat * (sign * delta_F);
-    number contrib_minus = meta::get_pair_contribution(settings, pair);
-    
-    _current_particle->pos = old_pos;  // Restore
-    
-    return (contrib_plus - contrib_minus) / (2.0 * delta_F);
-}
-
 LR_vector LTCoordination::_dcoord_dtheta() {
-    static number delta = 1e-6;
-    
     // Get the pair this particle belongs to
     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
     
@@ -223,45 +206,21 @@ LR_vector LTCoordination::_dcoord_dtheta() {
     // here we use a central difference scheme, perturbing the orientation around each axis 
     // *in the lab reference frame* in both directions and computing the contribution to the 
     // coordination from the pair this particle belongs to
-    
-    // Central difference: Perturb rotation around x-axis (positive)
-    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(1, 0, 0), delta) * old_orient;
-    _current_particle->orientationT = _current_particle->orientation.get_transpose();
-    _current_particle->set_positions();
-    contrib_plus = meta::get_pair_contribution(settings, pair);
-    
-    // Central difference: Perturb rotation around x-axis (negative)
-    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(1, 0, 0), -delta) * old_orient;
-    _current_particle->orientationT = _current_particle->orientation.get_transpose();
-    _current_particle->set_positions();
-    contrib_minus = meta::get_pair_contribution(settings, pair);
-    dcoord_dtheta.x = (contrib_plus - contrib_minus) / (2.0 * delta);
-    
-    // Central difference: Perturb rotation around y-axis (positive)
-    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 1, 0), delta) * old_orient;
-    _current_particle->orientationT = _current_particle->orientation.get_transpose();
-    _current_particle->set_positions();
-    contrib_plus = meta::get_pair_contribution(settings, pair);
-    
-    // Central difference: Perturb rotation around y-axis (negative)
-    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 1, 0), -delta) * old_orient;
-    _current_particle->orientationT = _current_particle->orientation.get_transpose();
-    _current_particle->set_positions();
-    contrib_minus = meta::get_pair_contribution(settings, pair);
-    dcoord_dtheta.y = (contrib_plus - contrib_minus) / (2.0 * delta);
-    
-    // Central difference: Perturb rotation around z-axis (positive)
-    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 0, 1), delta) * old_orient;
-    _current_particle->orientationT = _current_particle->orientation.get_transpose();
-    _current_particle->set_positions();
-    contrib_plus = meta::get_pair_contribution(settings, pair);
-    
-    // Central difference: Perturb rotation around z-axis (negative)
-    _current_particle->orientation = Utils::get_rotation_matrix_from_axis_angle(LR_vector(0, 0, 1), -delta) * old_orient;
-    _current_particle->orientationT = _current_particle->orientation.get_transpose();
-    _current_particle->set_positions();
-    contrib_minus = meta::get_pair_contribution(settings, pair);
-    dcoord_dtheta.z = (contrib_plus - contrib_minus) / (2.0 * delta);
+    for(int i = 0; i < 3; i++) {
+        // positive rotation
+        _current_particle->orientation = _rot_matrices[i][0] * old_orient;
+        _current_particle->orientationT = _current_particle->orientation.get_transpose();
+        _current_particle->set_positions();
+        contrib_plus = meta::get_pair_contribution(settings, pair);
+
+        // negative rotation
+        _current_particle->orientation = _rot_matrices[i][1] * old_orient;
+        _current_particle->orientationT = _current_particle->orientation.get_transpose();
+        _current_particle->set_positions();
+        contrib_minus = meta::get_pair_contribution(settings, pair);
+
+        dcoord_dtheta[i] = (contrib_plus - contrib_minus) / (2.0 * delta_T);
+    }
     
     // Restore original orientation
     _current_particle->orientation = old_orient;
@@ -269,4 +228,12 @@ LR_vector LTCoordination::_dcoord_dtheta() {
     _current_particle->set_positions();
     
     return dcoord_dtheta;
+}
+
+number LTCoordination::_coordination(llint step) {
+    if(step != _last_step_calculated) {
+        _current_coordination = Utils::clamp(meta::coordination(settings, all_pairs), coord_min, coord_max);
+        _last_step_calculated = step;
+    }
+    return _current_coordination;
 }

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -103,7 +103,7 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
     auto pair = all_pairs[particle_to_pair_index[_current_particle]];
     int sign = (pair.first == _current_particle) ? -1 : 1;
 
-    LR_vector r_vec = CONFIG_INFO->box->min_image(pair.first->pos, pair.second->pos);
+    LR_vector r_vec = _distance(pair);
     number r = r_vec.module();
     double x = (r - d0) / r0;
     double xn = std::pow(x, n);
@@ -127,6 +127,13 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
     return (number) sign * r_vec * (df_dcoord * dcoord_dr / r);
 }
 
+LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
+    LR_vector F = force(step, pos);
+    LR_vector torque = _current_particle->int_centers[DNANucleotide::BASE].cross(F);
+
+    return torque;
+}
+
 number LTCoordination::potential(llint step, LR_vector &pos) {
     number coord = Utils::clamp(_coordination(), coord_min, coord_max); // ensure we are within the grid limits
     int ic_left = std::floor((coord - coord_min) / d_coord);
@@ -143,10 +150,17 @@ number LTCoordination::potential(llint step, LR_vector &pos) {
     return my_potential / (2.0 * all_pairs.size()); // divide by 2 to avoid double counting
 }
 
+LR_vector LTCoordination::_distance(std::pair<BaseParticle *, BaseParticle *> &pair) {
+    LR_vector p_base = pair.first->pos + pair.first->int_centers[DNANucleotide::BASE];
+    LR_vector q_base = pair.second->pos + pair.second->int_centers[DNANucleotide::BASE];
+
+    return CONFIG_INFO->box->min_image(p_base, q_base);
+}
+
 double LTCoordination::_coordination() {
     number coordination = 0.0;
     for(auto &pair : all_pairs) {
-        number r = std::sqrt(CONFIG_INFO->box->sqr_min_image_distance(pair.first->pos, pair.second->pos));
+        number r = _distance(pair).module();
         coordination += 1.0 / (1.0 + std::pow((r - d0) / r0, n));
     }
 

--- a/src/Forces/Metadynamics/LTCoordination.cpp
+++ b/src/Forces/Metadynamics/LTCoordination.cpp
@@ -117,15 +117,12 @@ LR_vector LTCoordination::force(llint step, LR_vector &pos) {
 		df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
 	}
 
-    LR_vector dcoord_dpos = _dcoord_dpos();
-
-    // DNANucleotide p = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.first : pair.second);
-    // DNANucleotide q = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.second : pair.first);
-    // p.force = LR_vector();
-    // q.force = LR_vector();
-    // CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, &p, &q, true, true);
-    // printf("FORCE %d\n\t%g %g %g\n", p.index, p.force.x, p.force.y, p.force.z);
-    // printf("\t%g %g %g\n", dcoord_dpos.x, dcoord_dpos.y, dcoord_dpos.z);
+    // std::cout << "F OLD " << _dcoord_dpos() << std::endl;
+    // auto pair = all_pairs[particle_to_pair_index[_current_particle]];
+    auto force_torque = meta::get_pair_force_torque_contribution(settings, all_pairs[particle_to_pair_index[_current_particle]], _current_particle);
+    LR_vector dcoord_dpos = force_torque.first;
+    // auto F = dcoord_dpos;
+    // std::cout << "F NEW " << F << std::endl;
 
     return dcoord_dpos * df_dcoord;
 }
@@ -140,17 +137,11 @@ LR_vector LTCoordination::torque(llint step, LR_vector &pos) {
         df_dcoord = meta::get_x_force(coord, d_coord, coord_min, potential_grid);
     }
 
-    LR_vector dcoord_dtheta = _dcoord_dtheta();
-
-    // auto pair = all_pairs[particle_to_pair_index[_current_particle]];
-    // DNANucleotide p = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.first : pair.second);
-    // DNANucleotide q = *dynamic_cast<DNANucleotide *>(_current_particle == pair.first ? pair.second : pair.first);
-    // p.force = LR_vector();
-    // q.force = LR_vector();
-    // LR_vector pref_torque = _current_particle->orientationT * dcoord_dtheta;
-    // CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, &p, &q, true, true);
-    // printf("TORQUE %d\n\t%g %g %g\n", p.index, p.torque.x, p.torque.y, p.torque.z);
-    // printf("\t%g %g %g\n", pref_torque.x, pref_torque.y, pref_torque.z);
+    // std::cout << "T OLD " << _dcoord_dtheta() << std::endl;
+    auto force_torque = meta::get_pair_force_torque_contribution(settings, all_pairs[particle_to_pair_index[_current_particle]], _current_particle);
+    LR_vector dcoord_dtheta = force_torque.second;
+    // auto torque = dcoord_dtheta;
+    // std::cout << "T NEW " << torque << std::endl;
 
     return dcoord_dtheta * df_dcoord;
 }
@@ -166,7 +157,6 @@ number LTCoordination::potential(llint step, LR_vector &pos) {
 	}
 	else {
 		my_potential = meta::interpolate_potential(coord, d_coord, coord_min, potential_grid);
-        // printf("coord = %lf, index = %d, potential = %lf\n", coord, ic_left, my_potential);
 	}
 
     return my_potential / (2.0 * all_pairs.size()); // divide by 2 to avoid double counting

--- a/src/Forces/Metadynamics/LTCoordination.h
+++ b/src/Forces/Metadynamics/LTCoordination.h
@@ -42,6 +42,7 @@ public:
     std::vector<number> potential_grid;
 
 private:
+    LR_vector _dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &pair);
     number _dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair);
     LR_vector _dcoord_dtheta();
 };

--- a/src/Forces/Metadynamics/LTCoordination.h
+++ b/src/Forces/Metadynamics/LTCoordination.h
@@ -20,7 +20,7 @@ public:
 
     std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	LR_vector value(llint step, LR_vector &pos) override;
+	LR_vector force(llint step, LR_vector &pos) override;
 	number potential(llint step, LR_vector &pos) override;
 
     std::vector<std::pair<BaseParticle *, BaseParticle *>> all_pairs;

--- a/src/Forces/Metadynamics/LTCoordination.h
+++ b/src/Forces/Metadynamics/LTCoordination.h
@@ -44,11 +44,13 @@ public:
     std::vector<number> potential_grid;
 
 private:
-    LR_vector _dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &pair);
-    number _dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair);
-    LR_vector _dcoord_dtheta();
-
+    number _current_coordination;
+    llint _last_step_calculated = -1; // to avoid recalculating the coordination number multiple times in the same step (e.g. for different particles belonging to the same pair)
     LR_matrix _rot_matrices[3][2]; // rotation matrices for the 3 possible rotation axes and 2 possible directions of rotation (positive or negative)
+
+    LR_vector _dcoord_dpos();
+    LR_vector _dcoord_dtheta();
+    number _coordination(llint step);
 };
 
 #endif /* LTCOORDINATION_H */

--- a/src/Forces/Metadynamics/LTCoordination.h
+++ b/src/Forces/Metadynamics/LTCoordination.h
@@ -21,24 +21,27 @@ public:
     std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
 	LR_vector force(llint step, LR_vector &pos) override;
+    LR_vector torque(llint step, LR_vector &pos) override;
 	number potential(llint step, LR_vector &pos) override;
 
+    // all pairs of particles involved in the coordination number calculation
+    // (i.e. all pairs of particles that are part of the same hydrogen-bond-based order parameter defined in the OP file)
     std::vector<std::pair<BaseParticle *, BaseParticle *>> all_pairs;
 
-    // unfortunately forces in oxDNA are passed vectors rather than particles,
-    // so we need to keep a map from positions to pair of particles
+    // mapping from particle pointer to the index of the pair it belongs to in the all_pairs vector
     std::unordered_map<BaseParticle *, int> particle_to_pair_index;
 
     number coord_min; // minimum coordination number, defaults to 0.0
 	number coord_max; // maximum coordination number, defaults to the number of pairs defined in the OP file
 	int N_grid;
 	number d_coord; // grid spacing
-    number d0 = 1.2; // optimal distance for coordination, defaults to 1.2 in internal units
+    number d0 = 0.4; // optimal distance for coordination, defaults to 1.2 in internal units
     number r0 = 0.5; // width of the switching function, defaults to 0.5 in internal units
     int n = 6; // exponent of the switching function, defaults to 6
     std::vector<number> potential_grid;
 
 private:
+    LR_vector _distance(std::pair<BaseParticle *, BaseParticle *> &pair);
     number _coordination();
 };
 

--- a/src/Forces/Metadynamics/LTCoordination.h
+++ b/src/Forces/Metadynamics/LTCoordination.h
@@ -37,8 +37,6 @@ public:
 	number coord_max; // maximum coordination number, defaults to the number of pairs defined in the OP file
 	int N_grid;
 	number d_coord; // grid spacing
-    number delta_F = 1e-6; // displacement for finite difference calculation of the force
-    number delta_T = 1e-6; // displacement for finite difference calculation of the torque
 
     meta::CoordSettings settings;
     std::vector<number> potential_grid;
@@ -46,10 +44,16 @@ public:
 private:
     number _current_coordination;
     llint _last_step_calculated = -1; // to avoid recalculating the coordination number multiple times in the same step (e.g. for different particles belonging to the same pair)
-    LR_matrix _rot_matrices[3][2]; // rotation matrices for the 3 possible rotation axes and 2 possible directions of rotation (positive or negative)
 
+    // the two methods below use finite difference to calculate the derivatives of the coordination number with respect 
+    // to particle position and orientation, which are then used to calculate forces and torques. They are not currently
+    // used but can be useful if we want to implement a more complex potential that cannot be easily differentiated analytically.
     LR_vector _dcoord_dpos();
     LR_vector _dcoord_dtheta();
+    LR_matrix _rot_matrices[3][2]; // rotation matrices for the 3 possible rotation axes and 2 possible directions of rotation (positive or negative)
+    number _delta_F = 1e-6; // displacement for finite difference calculation of the force
+    number _delta_T = 1e-6; // displacement for finite difference calculation of the torque
+
     number _coordination(llint step);
 };
 

--- a/src/Forces/Metadynamics/LTCoordination.h
+++ b/src/Forces/Metadynamics/LTCoordination.h
@@ -9,8 +9,10 @@
 #define LTCOORDINATION_H
 
 #include "../BaseForce.h"
+#include "meta_utils.h"
 
 #include <unordered_map>
+#include <string>
 
 class LTCoordination: public BaseForce {
 public:
@@ -35,14 +37,13 @@ public:
 	number coord_max; // maximum coordination number, defaults to the number of pairs defined in the OP file
 	int N_grid;
 	number d_coord; // grid spacing
-    number d0 = 0.4; // optimal distance for coordination, defaults to 1.2 in internal units
-    number r0 = 0.5; // width of the switching function, defaults to 0.5 in internal units
-    int n = 6; // exponent of the switching function, defaults to 6
+
+    meta::CoordSettings settings;
     std::vector<number> potential_grid;
 
 private:
-    LR_vector _distance(std::pair<BaseParticle *, BaseParticle *> &pair);
-    number _coordination();
+    number _dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair);
+    LR_vector _dcoord_dtheta();
 };
 
 #endif /* LTCOORDINATION_H */

--- a/src/Forces/Metadynamics/LTCoordination.h
+++ b/src/Forces/Metadynamics/LTCoordination.h
@@ -37,6 +37,8 @@ public:
 	number coord_max; // maximum coordination number, defaults to the number of pairs defined in the OP file
 	int N_grid;
 	number d_coord; // grid spacing
+    number delta_F = 1e-6; // displacement for finite difference calculation of the force
+    number delta_T = 1e-6; // displacement for finite difference calculation of the torque
 
     meta::CoordSettings settings;
     std::vector<number> potential_grid;
@@ -45,6 +47,8 @@ private:
     LR_vector _dcoord_dpos(std::pair<BaseParticle*, BaseParticle*> &pair);
     number _dcoord_dr(std::pair<BaseParticle*, BaseParticle*> &pair);
     LR_vector _dcoord_dtheta();
+
+    LR_matrix _rot_matrices[3][2]; // rotation matrices for the 3 possible rotation axes and 2 possible directions of rotation (positive or negative)
 };
 
 #endif /* LTCOORDINATION_H */

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -131,7 +131,6 @@ number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, B
 	else {
         // SWITCHING_FUNCTION mode
         number r = distance(pair).module();
-        // printf("%d %d %g\n", pair.first->index, pair.second->index, r);
         return 1.0 / (1.0 + std::pow((r - settings.d0) / settings.r0, settings.n));
     }
 }

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -122,9 +122,8 @@ number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle 
 }
 
 number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair) {
-    // Compute coordination contribution from a single pair
-    // Optimized since each particle belongs to only one pair
-    if(settings.coord_mode == 1) {  // HB_CUTOFF
+    // HB_CUTOFF mode: contribution is a smooth function of the HB energy of the pair
+    if(settings.coord_mode == 1) {
         number energy = hb_energy(pair.first, pair.second);
         return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, energy);
     }
@@ -136,14 +135,9 @@ number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, B
 }
 
 number hb_energy(BaseParticle *p1, BaseParticle *p2) {
-    // Compute hydrogen bonding energy between two particles
-    // This uses the interaction model's HB energy calculation
-    
-    LR_vector r = CONFIG_INFO->box->min_image(p1->pos, p2->pos);
-    CONFIG_INFO->interaction->set_computed_r(r);
-    
     // Get the hydrogen bonding interaction energy
-    number hb_energy = CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, p1, p2, false, false);
+    // TODO: get rid of the dynamic lookup by caching the interaction pointer in the CoordSettings struct
+    number hb_energy = CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, p1, p2, true, false);
     
     return hb_energy;
 }

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -136,31 +136,35 @@ number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, B
     // Avoid dynamic loopkup by caching the hydrogen bonding function pointer. This is important since this function is called many times during the force computation. 
     static BaseInteraction::energy_function HB_function = CONFIG_INFO->interaction->get_interaction_function(DNAInteraction::HYDROGEN_BONDING);
 
+    number contrib = 0.0;
     switch(settings.coord_mode) {
         case CoordSettings::CoordMode::HB_ENERGY: {
             LR_vector force, torque;
-            number hb_energy = hb_interaction(pair.first, pair.second, force, torque);
-            return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
+            number hb_energy = hb_interaction(pair.first, pair.second, force, torque, false);
+            contrib = smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
+            break;
         }
         case CoordSettings::CoordMode::SWITCHING_FUNCTION: {
             LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos + pair.first->int_centers[DNANucleotide::BASE], pair.second->pos + pair.second->int_centers[DNANucleotide::BASE]);
             number r_mod = r.module();
-            return 1.0 / (1.0 + std::pow((r_mod - settings.d0) / settings.r0, settings.n));
+            contrib =  1.0 / (1.0 + std::pow((r_mod - settings.d0) / settings.r0, settings.n));
+            break;
         }
         case CoordSettings::CoordMode::MIXED: {
             LR_vector force, torque;
-            number hb_energy = hb_interaction(pair.first, pair.second, force, torque);
+            number hb_energy = hb_interaction(pair.first, pair.second, force, torque, false);
             number hb_contribution = smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
 
             LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos + pair.first->int_centers[DNANucleotide::BASE], pair.second->pos + pair.second->int_centers[DNANucleotide::BASE]);
             number r_mod = r.module();
             number switching_contribution = 1.0 / (1.0 + std::pow((r_mod - settings.d0) / settings.r0, settings.n));
 
-            return settings.mixed_weight * hb_contribution + (1.0 - settings.mixed_weight) * switching_contribution;
+            contrib = settings.mixed_weight * hb_contribution + (1.0 - settings.mixed_weight) * switching_contribution;
+            break;
         }
     }
 
-    return 0.0; // should never be reached
+    return contrib;
 }
 
 std::pair<LR_vector, LR_vector> get_pair_force_torque_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair, BaseParticle *current_particle) {
@@ -172,7 +176,7 @@ std::pair<LR_vector, LR_vector> get_pair_force_torque_contribution(CoordSettings
 
     switch(settings.coord_mode) {
         case CoordSettings::CoordMode::HB_ENERGY: {
-            number hb_energy = hb_interaction(current_particle, other_particle, force, torque);
+            number hb_energy = hb_interaction(current_particle, other_particle, force, torque, true);
             number dcoord_dhb_energy = der_smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
             force *= dcoord_dhb_energy;
             torque *= dcoord_dhb_energy;
@@ -191,7 +195,7 @@ std::pair<LR_vector, LR_vector> get_pair_force_torque_contribution(CoordSettings
             break;
         }
         case CoordSettings::CoordMode::MIXED: {
-            number hb_energy = hb_interaction(current_particle, other_particle, force, torque);
+            number hb_energy = hb_interaction(current_particle, other_particle, force, torque, true);
             number dcoord_dhb_energy = der_smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
             LR_vector hb_force_contribution = force * dcoord_dhb_energy;
             LR_vector hb_torque_contribution = torque * dcoord_dhb_energy;
@@ -273,7 +277,7 @@ number _f4Dsin(number t, number t0, number a) {
 	return val;
 }
 
-number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vector &torque) {
+number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vector &torque, bool compute_force_torque) {
     force = torque = LR_vector();
     // true if p and q are Watson-Crick-like pairs
 	bool is_pair = (q->btype + p->btype == 3);
@@ -319,10 +323,9 @@ number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vec
 		number f4t8 = _f4(t8, HYDR_THETA8_T0, HYDR_THETA8_A);
 
 		energy = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8;
-        // printf("NEW  %d %d %lf %lf %lf %lf %lf %lf %lf %lf\n", p->index, q->index, energy, f1, f4t1, f4t2, f4t3, f4t4, f4t7, f4t8);
 
 		// makes sense, since the above functions may return 0. exactly
-		if(energy != 0.) {
+		if(compute_force_torque && energy != 0.) {
 			// derivatives called at the relevant arguments
 			number f1D = _f1D(rhydromod);
 			number f4t1Dsin =  _f4Dsin(t1, HYDR_THETA1_T0, HYDR_THETA1_A);

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -7,6 +7,9 @@
 
 #include "meta_utils.h"
 #include "../../Boxes/BaseBox.h"
+#include "../../Utilities/ConfigInfo.h"
+#include "../../Particles/DNANucleotide.h"
+#include "../../Interactions/DNAInteraction.h"
 
 #include <fast_double_parser/fast_double_parser.h>
 
@@ -64,6 +67,99 @@ std::vector<number> split_to_numbers(const std::string &str, const std::string &
 	}
 
 	return output;
+}
+
+CoordSettings::CoordSettings() {
+	coord_mode = 0;
+	hb_energy_cutoff = -0.2;
+	hb_transition_width = 0.1;
+	d0 = 0.4;
+	r0 = 0.5;
+	n = 6;
+}
+
+void CoordSettings::get_settings(input_file &inp) {
+	getInputNumber(&inp, "d0", &d0, 0);
+	getInputNumber(&inp, "r0", &r0, 0);
+    getInputInt(&inp, "n", &n, 0);
+
+    if(n % 2 != 0) {
+        throw oxDNAException("LTCoordination: exponent n must be an even integer");
+    }
+
+	// Parse coordination mode
+    std::string coord_type("hb_cutoff");
+    getInputString(&inp, "coordination_type", coord_type, 0);
+    if(coord_type == "switching_function") {
+        coord_mode = 0;  // SWITCHING_FUNCTION
+        OX_LOG(Logger::LOG_INFO, "LTCoordination: Using switching function for coordination");
+    } 
+    else if(coord_type == "hb_cutoff") {
+        coord_mode = 1;  // HB_CUTOFF
+        // Get HB parameters
+        getInputNumber(&inp, "hb_energy_cutoff", &hb_energy_cutoff, 0);
+        getInputNumber(&inp, "hb_transition_width", &hb_transition_width, 0);
+        OX_LOG(Logger::LOG_INFO, "Coordination: Using HB energy cutoff for coordination, hb_energy_cutoff = %.2f, hb_transition_width = %.2f", hb_energy_cutoff, hb_transition_width);
+    }
+    else {
+        throw oxDNAException("Coordination: unknown coordination_type '%s' (valid options: 'switching_function', 'hb_cutoff')", coord_type.c_str());
+    }
+}
+
+LR_vector distance(std::pair<BaseParticle *, BaseParticle *> &pair) {
+    LR_vector p_base = pair.first->pos + pair.first->int_centers[DNANucleotide::BASE];
+    LR_vector q_base = pair.second->pos + pair.second->int_centers[DNANucleotide::BASE];
+
+    return CONFIG_INFO->box->min_image(p_base, q_base);
+}
+
+number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle *, BaseParticle *>> &all_pairs) {
+    number coordination = 0.0;
+    for(auto &pair : all_pairs) {
+        coordination += get_pair_contribution(settings, pair);
+    }
+    return coordination;
+}
+
+number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair) {
+    // Compute coordination contribution from a single pair
+    // Optimized since each particle belongs to only one pair
+    if(settings.coord_mode == 1) {  // HB_CUTOFF
+        number energy = hb_energy(pair.first, pair.second);
+        return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, energy);
+    }
+	else {
+        // SWITCHING_FUNCTION mode
+        number r = distance(pair).module();
+        // printf("%d %d %g\n", pair.first->index, pair.second->index, r);
+        return 1.0 / (1.0 + std::pow((r - settings.d0) / settings.r0, settings.n));
+    }
+}
+
+number hb_energy(BaseParticle *p1, BaseParticle *p2) {
+    // Compute hydrogen bonding energy between two particles
+    // This uses the interaction model's HB energy calculation
+    
+    LR_vector r = CONFIG_INFO->box->min_image(p1->pos, p2->pos);
+    CONFIG_INFO->interaction->set_computed_r(r);
+    
+    // Get the hydrogen bonding interaction energy
+    number hb_energy = CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, p1, p2, false, false);
+    
+    return hb_energy;
+}
+
+number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy) {
+    // Smooth step function that transitions around hb_energy_cutoff
+    // Using tanh for smoothness: transitions from 1 (favorable HB, low energy) 
+    // to 0 (unfavorable, high energy)
+    number x = (hb_energy_cutoff - hb_energy) / hb_transition_width;
+    
+    // Clamp to avoid numerical overflow with tanh
+    if(x > 10.0) return 1.0;
+    if(x < -10.0) return 0.0;
+    
+    return 0.5 * (1.0 + tanh(x));
 }
 
 }

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -357,22 +357,25 @@ number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vec
             // t2 generates a torque on q, which is not needed here, so we don't compute it
 
 			// THETA3; t3 = LRACOS (a1 * rhydrodir);
-			force += (a1 - rhydrodir * cost3) * (f1 * f4t1 * f4t2 * f4t3Dsin * f4t4 * f4t7 * f4t8 / rhydromod);
+            fact = f1 * f4t1 * f4t2 * f4t3Dsin * f4t4 * f4t7 * f4t8;
+			force += (a1 - rhydrodir * cost3) * (fact / rhydromod);
 
 			LR_vector t3dir = rhydrodir.cross(a1);
-			torquemod = f1 * f4t1 * f4t2 * f4t3Dsin * f4t4 * f4t7 * f4t8;
+			torquemod = fact;
 
 			torque += t3dir * torquemod;
 
 			// THETA7; t7 = LRACOS (-rhydrodir * b3);
-			force += (b3 + rhydrodir * cost7) * (f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7Dsin * f4t8 / rhydromod);
+            fact = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7Dsin * f4t8;
+			force += (b3 + rhydrodir * cost7) * (fact / rhydromod);
             // t7 generates a torque on q, which is not needed here, so we don't compute it
 
 			// THETA 8; t8 = LRACOS (rhydrodir * a3);
-			force += (a3 - rhydrodir * cost8) * (f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8Dsin / rhydromod);
+            fact = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8Dsin;
+			force += (a3 - rhydrodir * cost8) * (fact / rhydromod);
 
 			LR_vector t8dir = rhydrodir.cross(a3);
-			torquemod = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8Dsin;
+			torquemod = fact;
 
 			torque += t8dir * torquemod;
 

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -70,7 +70,7 @@ std::vector<number> split_to_numbers(const std::string &str, const std::string &
 }
 
 CoordSettings::CoordSettings() {
-	coord_mode = 0;
+	coord_mode = CoordMode::HB_ENERGY;
 	hb_energy_cutoff = -0.2;
 	hb_transition_width = 0.1;
 	d0 = 0.4;
@@ -79,30 +79,48 @@ CoordSettings::CoordSettings() {
 }
 
 void CoordSettings::get_settings(input_file &inp) {
-	getInputNumber(&inp, "d0", &d0, 0);
-	getInputNumber(&inp, "r0", &r0, 0);
-    getInputInt(&inp, "n", &n, 0);
-
-    if(n % 2 != 0) {
-        throw oxDNAException("LTCoordination: exponent n must be an even integer");
-    }
-
 	// Parse coordination mode
     std::string coord_type("hb_cutoff");
     getInputString(&inp, "coordination_type", coord_type, 0);
-    if(coord_type == "switching_function") {
-        coord_mode = 0;  // SWITCHING_FUNCTION
-        OX_LOG(Logger::LOG_INFO, "LTCoordination: Using switching function for coordination");
-    } 
-    else if(coord_type == "hb_cutoff") {
-        coord_mode = 1;  // HB_CUTOFF
+    
+    // we need to parse all the parameters first, since they may be needed for multiple coordination modes
+    // (e.g. if coord_type == "mixed" we need both the HB energy parameters and the switching function parameters)
+    if(coord_type == "hb_cutoff" || coord_type == "mixed") {
+        coord_mode = CoordMode::HB_ENERGY;
         // Get HB parameters
         getInputNumber(&inp, "hb_energy_cutoff", &hb_energy_cutoff, 0);
         getInputNumber(&inp, "hb_transition_width", &hb_transition_width, 0);
-        OX_LOG(Logger::LOG_INFO, "Coordination: Using HB energy cutoff for coordination, hb_energy_cutoff = %.2f, hb_transition_width = %.2f", hb_energy_cutoff, hb_transition_width);
+        OX_LOG(Logger::LOG_INFO, "Coordination: hb_energy_cutoff = %.2f, hb_transition_width = %.2f", hb_energy_cutoff, hb_transition_width);
+    }
+    if(coord_type == "switching_function" || coord_type == "mixed") {
+        coord_mode = CoordMode::SWITCHING_FUNCTION;
+
+        getInputNumber(&inp, "d0", &d0, 0);
+        getInputNumber(&inp, "r0", &r0, 0);
+        getInputInt(&inp, "n", &n, 0);
+
+        if(n % 2 != 0) {
+            throw oxDNAException("LTCoordination: exponent n must be an even integer");
+        }
+        OX_LOG(Logger::LOG_INFO, "Coordination: switching function with d0 = %.2f, r0 = %.2f, n = %d", d0, r0, n);
+    } 
+
+    if(coord_type == "hb_cutoff") {
+        OX_LOG(Logger::LOG_INFO, "Coordination: Using HB energy cutoff coordination");
+    }
+    else if(coord_type == "switching_function") {
+        OX_LOG(Logger::LOG_INFO, "Coordination: Using switching function coordination");
+    }
+    else if(coord_type == "mixed") {
+        coord_mode = CoordMode::MIXED;
+        getInputNumber(&inp, "mixed_weight", &mixed_weight, 1);
+        if(mixed_weight < 0.0 || mixed_weight > 1.0) {
+            throw oxDNAException("Coordination: mixed_weight must be between 0 and 1");
+        }
+        OX_LOG(Logger::LOG_INFO, "Coordination: Using mixed coordination with mixed_weight = %.2f", mixed_weight);
     }
     else {
-        throw oxDNAException("Coordination: unknown coordination_type '%s' (valid options: 'switching_function', 'hb_cutoff')", coord_type.c_str());
+        throw oxDNAException("Coordination: unknown coordination_type '%s' (valid options: 'switching_function', 'hb_cutoff', 'mixed')", coord_type.c_str());
     }
 }
 
@@ -122,17 +140,35 @@ number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle 
 }
 
 number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair) {
-    // HB_CUTOFF mode: contribution is a smooth function of the HB energy of the pair
-    if(settings.coord_mode == 1) {
-        // TODO: get rid of the dynamic lookup by caching the interaction pointer in the CoordSettings struct
-        number hb_energy = CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, pair.first, pair.second, true, false);
-        return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
+    // Avoid dynamic loopkup by caching the hydrogen bonding function pointer. This is important since this function is called many times during the force computation. 
+        static BaseInteraction::energy_function HB_function = CONFIG_INFO->interaction->get_interaction_function(DNAInteraction::HYDROGEN_BONDING);
+
+    switch(settings.coord_mode) {
+        case CoordSettings::CoordMode::HB_ENERGY: {
+            LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos, pair.second->pos);
+            CONFIG_INFO->interaction->set_computed_r(r);
+            number hb_energy = HB_function(pair.first, pair.second, false, false);
+            return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
+        }
+        case CoordSettings::CoordMode::SWITCHING_FUNCTION: {
+            number r_mod = distance(pair).module();
+            return 1.0 / (1.0 + std::pow((r_mod - settings.d0) / settings.r0, settings.n));
+        }
+        case CoordSettings::CoordMode::MIXED: {
+            // we compute both contributions and then mix them with the specified weight
+            LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos, pair.second->pos);
+            CONFIG_INFO->interaction->set_computed_r(r);
+            number hb_energy = HB_function(pair.first, pair.second, false, false);
+            number hb_contribution = smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
+
+            number r_mod = distance(pair).module();
+            number switching_contribution = 1.0 / (1.0 + std::pow((r_mod - settings.d0) / settings.r0, settings.n));
+
+            return settings.mixed_weight * hb_contribution + (1.0 - settings.mixed_weight) * switching_contribution;
+        }
     }
-	else {
-        // SWITCHING_FUNCTION mode
-        number r = distance(pair).module();
-        return 1.0 / (1.0 + std::pow((r - settings.d0) / settings.r0, settings.n));
-    }
+
+    return 0.0; // should never be reached
 }
 
 number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy) {

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -124,22 +124,15 @@ number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle 
 number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair) {
     // HB_CUTOFF mode: contribution is a smooth function of the HB energy of the pair
     if(settings.coord_mode == 1) {
-        number energy = hb_energy(pair.first, pair.second);
-        return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, energy);
+        // TODO: get rid of the dynamic lookup by caching the interaction pointer in the CoordSettings struct
+        number hb_energy = CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, pair.first, pair.second, true, false);
+        return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
     }
 	else {
         // SWITCHING_FUNCTION mode
         number r = distance(pair).module();
         return 1.0 / (1.0 + std::pow((r - settings.d0) / settings.r0, settings.n));
     }
-}
-
-number hb_energy(BaseParticle *p1, BaseParticle *p2) {
-    // Get the hydrogen bonding interaction energy
-    // TODO: get rid of the dynamic lookup by caching the interaction pointer in the CoordSettings struct
-    number hb_energy = CONFIG_INFO->interaction->pair_interaction_term(DNAInteraction::HYDROGEN_BONDING, p1, p2, true, false);
-    
-    return hb_energy;
 }
 
 number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy) {
@@ -151,7 +144,7 @@ number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_widt
     // Clamp to avoid numerical overflow with tanh
     if(x > 10.0) return 1.0;
     if(x < -10.0) return 0.0;
-    
+
     return 0.5 * (1.0 + tanh(x));
 }
 

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -124,13 +124,6 @@ void CoordSettings::get_settings(input_file &inp) {
     }
 }
 
-LR_vector distance(std::pair<BaseParticle *, BaseParticle *> &pair) {
-    LR_vector p_base = pair.first->pos + pair.first->int_centers[DNANucleotide::BASE];
-    LR_vector q_base = pair.second->pos + pair.second->int_centers[DNANucleotide::BASE];
-
-    return CONFIG_INFO->box->min_image(p_base, q_base);
-}
-
 number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle *, BaseParticle *>> &all_pairs) {
     number coordination = 0.0;
     for(auto &pair : all_pairs) {
@@ -141,27 +134,26 @@ number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle 
 
 number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair) {
     // Avoid dynamic loopkup by caching the hydrogen bonding function pointer. This is important since this function is called many times during the force computation. 
-        static BaseInteraction::energy_function HB_function = CONFIG_INFO->interaction->get_interaction_function(DNAInteraction::HYDROGEN_BONDING);
+    static BaseInteraction::energy_function HB_function = CONFIG_INFO->interaction->get_interaction_function(DNAInteraction::HYDROGEN_BONDING);
 
     switch(settings.coord_mode) {
         case CoordSettings::CoordMode::HB_ENERGY: {
-            LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos, pair.second->pos);
-            CONFIG_INFO->interaction->set_computed_r(r);
-            number hb_energy = HB_function(pair.first, pair.second, false, false);
+            LR_vector force, torque;
+            number hb_energy = hb_interaction(pair.first, pair.second, force, torque);
             return smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
         }
         case CoordSettings::CoordMode::SWITCHING_FUNCTION: {
-            number r_mod = distance(pair).module();
+            LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos + pair.first->int_centers[DNANucleotide::BASE], pair.second->pos + pair.second->int_centers[DNANucleotide::BASE]);
+            number r_mod = r.module();
             return 1.0 / (1.0 + std::pow((r_mod - settings.d0) / settings.r0, settings.n));
         }
         case CoordSettings::CoordMode::MIXED: {
-            // we compute both contributions and then mix them with the specified weight
-            LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos, pair.second->pos);
-            CONFIG_INFO->interaction->set_computed_r(r);
-            number hb_energy = HB_function(pair.first, pair.second, false, false);
+            LR_vector force, torque;
+            number hb_energy = hb_interaction(pair.first, pair.second, force, torque);
             number hb_contribution = smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
 
-            number r_mod = distance(pair).module();
+            LR_vector r = CONFIG_INFO->box->min_image(pair.first->pos + pair.first->int_centers[DNANucleotide::BASE], pair.second->pos + pair.second->int_centers[DNANucleotide::BASE]);
+            number r_mod = r.module();
             number switching_contribution = 1.0 / (1.0 + std::pow((r_mod - settings.d0) / settings.r0, settings.n));
 
             return settings.mixed_weight * hb_contribution + (1.0 - settings.mixed_weight) * switching_contribution;
@@ -169,6 +161,235 @@ number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, B
     }
 
     return 0.0; // should never be reached
+}
+
+std::pair<LR_vector, LR_vector> get_pair_force_torque_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair, BaseParticle *current_particle) {
+    // Avoid dynamic loopkup by caching the hydrogen bonding function pointer. This is important since this function is called many times during the force computation. 
+    static BaseInteraction::energy_function HB_function = CONFIG_INFO->interaction->get_interaction_function(DNAInteraction::HYDROGEN_BONDING);
+
+    LR_vector force, torque;
+    BaseParticle *other_particle = (current_particle == pair.first) ? pair.second : pair.first;
+
+    switch(settings.coord_mode) {
+        case CoordSettings::CoordMode::HB_ENERGY: {
+            number hb_energy = hb_interaction(current_particle, other_particle, force, torque);
+            number dcoord_dhb_energy = der_smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
+            force *= dcoord_dhb_energy;
+            torque *= dcoord_dhb_energy;
+            break;
+        }
+        case CoordSettings::CoordMode::SWITCHING_FUNCTION: {
+            LR_vector r_vec = CONFIG_INFO->box->min_image(current_particle->pos + current_particle->int_centers[DNANucleotide::BASE], other_particle->pos + other_particle->int_centers[DNANucleotide::BASE]);
+            number r_mod = r_vec.module();
+
+            number x = (r_mod - settings.d0) / settings.r0;
+            number xn = std::pow(x, settings.n);
+            number dcoord_dr = (settings.n / settings.r0) * std::pow(x, settings.n - 1) / (SQR(1.0 + xn));
+
+            force = r_vec / r_mod * dcoord_dr;
+            torque = current_particle->int_centers[DNANucleotide::BASE].cross(force);
+            break;
+        }
+        case CoordSettings::CoordMode::MIXED: {
+            number hb_energy = hb_interaction(current_particle, other_particle, force, torque);
+            number dcoord_dhb_energy = der_smooth_hb_contribution(settings.hb_energy_cutoff, settings.hb_transition_width, hb_energy);
+            LR_vector hb_force_contribution = force * dcoord_dhb_energy;
+            LR_vector hb_torque_contribution = torque * dcoord_dhb_energy;
+
+            LR_vector r_vec = CONFIG_INFO->box->min_image(current_particle->pos + current_particle->int_centers[DNANucleotide::BASE], other_particle->pos + other_particle->int_centers[DNANucleotide::BASE]);
+            number r_mod = r_vec.module();
+
+            number x = (r_mod - settings.d0) / settings.r0;
+            number xn = std::pow(x, settings.n);
+            number dcoord_dr = (settings.n / settings.r0) * std::pow(x, settings.n - 1) / (SQR(1.0 + xn));
+
+            LR_vector switching_force_contribution = r_vec / r_mod * dcoord_dr;
+            LR_vector switching_torque_contribution = current_particle->int_centers[DNANucleotide::BASE].cross(switching_force_contribution);
+
+            force = settings.mixed_weight * hb_force_contribution + (1.0 - settings.mixed_weight) * switching_force_contribution;
+            torque = settings.mixed_weight * hb_torque_contribution + (1.0 - settings.mixed_weight) * switching_torque_contribution;
+            break;
+        }
+    }
+
+    return std::make_pair(force, torque);
+}
+
+// here we got ridden of the smoothing function that is present in the original oxDNA code
+number _f1(number r) {
+    static number shift = HYDR_EPS_OXDNA2 * SQR(1.0 - exp(-(HYDR_RC - HYDR_R0) * HYDR_A));
+
+	number val = 0.0;
+	if(r < HYDR_RCHIGH) {
+        number tmp = 1.0 - exp(-(r - HYDR_R0) * HYDR_A);
+        val = HYDR_EPS_OXDNA2 * SQR(tmp) - shift;
+	}
+
+	return val;
+}
+
+number _f1D(number r) {
+	number val = 0.0;
+	if(r < HYDR_RCHIGH) {
+        number tmp = exp(-(r - HYDR_R0) * HYDR_A);
+        val = 2.0 * HYDR_EPS_OXDNA2 * (1 - tmp) * tmp * HYDR_A;
+	}
+
+	return val;
+}
+
+number _f4(number t, number t0, number a) {
+	number val = 0.0;
+	t -= t0;
+	if(t < 0.0) {
+		t *= -1.0;
+    }
+
+    // here we compute the cut-off "by hand", since the oxDNA cut-off takes 
+    // into account also the smoothing function, which we don't use.
+	if(t < 1.0 / std::sqrt(a)) {
+        val = 1.0 - a * SQR(t);
+	}
+
+	return val;
+}
+
+number _f4Dsin(number t, number t0, number a) {
+	number val = 0.0;
+	number m = 1.0;
+	number tt0 = t - t0;
+	// this function is a parabola centered in t0. If t < 0 then the value of the function
+	// is the same but the value of its derivative has the opposite sign, so m = -1
+	if(tt0 < 0.0) {
+		tt0 *= -1.0;
+		m = -1.0;
+	}
+
+	if(tt0 < 1.0 / std::sqrt(a)) {
+        number sint = sin(t);
+        val = m * 2.0 * a * tt0 / sint;
+	}
+
+	return val;
+}
+
+number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vector &torque) {
+    force = torque = LR_vector();
+    // true if p and q are Watson-Crick-like pairs
+	bool is_pair = (q->btype + p->btype == 3);
+
+    LR_vector r = CONFIG_INFO->box->min_image(p->pos, q->pos);
+	LR_vector rhydro = r + q->int_centers[DNANucleotide::BASE] - p->int_centers[DNANucleotide::BASE];
+	number rhydromod = rhydro.module();
+	number energy = (number) 0.f;
+	if(is_pair && HYDR_RCLOW < rhydromod && rhydromod < HYDR_RCHIGH) {
+		// vector, versor and magnitude of the base-base separation
+		LR_vector rhydrodir = rhydro / rhydromod;
+
+		// particle axes according to Allen's paper
+		LR_vector &a1 = p->orientationT.v1;
+		LR_vector &a3 = p->orientationT.v3;
+		LR_vector &b1 = q->orientationT.v1;
+		LR_vector &b3 = q->orientationT.v3;
+
+		// angles involved in the HB interaction
+		number cost1 = -a1 * b1;
+		number cost2 = -b1 * rhydrodir;
+		number cost3 =  a1 * rhydrodir;
+
+		number cost4 =  a3 * b3;
+		number cost7 = -b3 * rhydrodir;
+		number cost8 =  a3 * rhydrodir;
+
+        number t1 = Utils::safe_acos(cost1);
+        number t2 = Utils::safe_acos(cost2);
+        number t3 = Utils::safe_acos(cost3);
+        number t4 = Utils::safe_acos(cost4);
+        number t7 = Utils::safe_acos(cost7);
+        number t8 = Utils::safe_acos(cost8);
+
+		// functions called at their relevant arguments
+		number f1 = _f1(rhydromod);
+		number f4t1 = _f4(t1, HYDR_THETA1_T0, HYDR_THETA1_A);
+		number f4t2 = _f4(t2, HYDR_THETA2_T0, HYDR_THETA2_A);
+		number f4t3 = _f4(t3, HYDR_THETA3_T0, HYDR_THETA3_A);
+
+		number f4t4 = _f4(t4, HYDR_THETA4_T0, HYDR_THETA4_A);
+		number f4t7 = _f4(t7, HYDR_THETA7_T0, HYDR_THETA7_A);
+		number f4t8 = _f4(t8, HYDR_THETA8_T0, HYDR_THETA8_A);
+
+		energy = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8;
+        // printf("NEW  %d %d %lf %lf %lf %lf %lf %lf %lf %lf\n", p->index, q->index, energy, f1, f4t1, f4t2, f4t3, f4t4, f4t7, f4t8);
+
+		// makes sense, since the above functions may return 0. exactly
+		if(energy != 0.) {
+			// derivatives called at the relevant arguments
+			number f1D = _f1D(rhydromod);
+			number f4t1Dsin =  _f4Dsin(t1, HYDR_THETA1_T0, HYDR_THETA1_A);
+			number f4t2Dsin =  _f4Dsin(t2, HYDR_THETA2_T0, HYDR_THETA2_A);
+			number f4t3Dsin = -_f4Dsin(t3, HYDR_THETA3_T0, HYDR_THETA3_A);
+
+			number f4t4Dsin = -_f4Dsin(t4, HYDR_THETA4_T0, HYDR_THETA4_A);
+			number f4t7Dsin =  _f4Dsin(t7, HYDR_THETA7_T0, HYDR_THETA7_A);
+			number f4t8Dsin = -_f4Dsin(t8, HYDR_THETA8_T0, HYDR_THETA8_A);
+
+			// RADIAL PART
+			force = -rhydrodir * (f1D * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8);
+
+			// THETA4; t4 = LRACOS (a3 * b3);
+			LR_vector dir = a3.cross(b3);
+			number torquemod = -f1 * f4t1 * f4t2 * f4t3 * f4t4Dsin * f4t7 * f4t8;
+
+			torque += dir * torquemod;
+
+			// THETA1; t1 = LRACOS (-a1 * b1);
+			dir = a1.cross(b1);
+			torquemod = -f1 * f4t1Dsin * f4t2 * f4t3 * f4t4 * f4t7 * f4t8;
+
+			torque += dir * torquemod;
+
+			// THETA2; t2 = LRACOS (-b1 * rhydrodir);
+			number fact = f1 * f4t1 * f4t2Dsin * f4t3 * f4t4 * f4t7 * f4t8;
+			force += (b1 + rhydrodir * cost2) * (fact / rhydromod);
+            // t2 generates a torque on q, which is not needed here, so we don't compute it
+
+			// THETA3; t3 = LRACOS (a1 * rhydrodir);
+			force += (a1 - rhydrodir * cost3) * (f1 * f4t1 * f4t2 * f4t3Dsin * f4t4 * f4t7 * f4t8 / rhydromod);
+
+			LR_vector t3dir = rhydrodir.cross(a1);
+			torquemod = f1 * f4t1 * f4t2 * f4t3Dsin * f4t4 * f4t7 * f4t8;
+
+			torque += t3dir * torquemod;
+
+			// THETA7; t7 = LRACOS (-rhydrodir * b3);
+			force += (b3 + rhydrodir * cost7) * (f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7Dsin * f4t8 / rhydromod);
+            // t7 generates a torque on q, which is not needed here, so we don't compute it
+
+			// THETA 8; t8 = LRACOS (rhydrodir * a3);
+			force += (a3 - rhydrodir * cost8) * (f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8Dsin / rhydromod);
+
+			LR_vector t8dir = rhydrodir.cross(a3);
+			torquemod = f1 * f4t1 * f4t2 * f4t3 * f4t4 * f4t7 * f4t8Dsin;
+
+			torque += t8dir * torquemod;
+
+			torque += p->int_centers[DNANucleotide::BASE].cross(force);
+		}
+	}
+
+	return energy;
+}
+
+number der_smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy) {
+    number x = (hb_energy_cutoff - hb_energy) / hb_transition_width;
+    
+    // Clamp to avoid numerical overflow with tanh
+    if(x > 10.0) return 0.0;
+    if(x < -10.0) return 0.0;
+
+    // derivative of the smooth step function with respect to the HB energy
+    number tanh_x = std::tanh(x);
+    return -0.5 * (1.0 - SQR(tanh_x)) / hb_transition_width;
 }
 
 number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy) {

--- a/src/Forces/Metadynamics/meta_utils.cpp
+++ b/src/Forces/Metadynamics/meta_utils.cpp
@@ -270,8 +270,13 @@ number _f4Dsin(number t, number t0, number a) {
 	}
 
 	if(tt0 < 1.0 / std::sqrt(a)) {
-        number sint = sin(t);
-        val = m * 2.0 * a * tt0 / sint;
+        number sint = std::sin(t);
+        // for perfectly aligned nucleotides, i.e. for generated structures, the value of sint may be 0.
+        // This would cause the derivative diverge here (which in reality is compensated by how this 
+        // contribution is multiplied by the combination of vectors involved in the angle calculation).
+        // To avoid the divergence we assume that t - t0 = t, so that we can write t / sin(t) = 1,
+        // which is wrong but will happen only at the very beginning of a simulation.
+        val = (sint > 1e-10) ? m * 2.0 * a * tt0 / sint : m * 2.0 * a;
 	}
 
 	return val;

--- a/src/Forces/Metadynamics/meta_utils.h
+++ b/src/Forces/Metadynamics/meta_utils.h
@@ -52,7 +52,6 @@ struct CoordSettings {
 LR_vector distance(std::pair<BaseParticle *, BaseParticle *> &pair);
 number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle *, BaseParticle *>> &all_pairs);
 number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair);
-number hb_energy(BaseParticle *p1, BaseParticle *p2);
 number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy);
 
 }

--- a/src/Forces/Metadynamics/meta_utils.h
+++ b/src/Forces/Metadynamics/meta_utils.h
@@ -52,9 +52,11 @@ struct CoordSettings {
 	void get_settings(input_file &inp);
 };
 
-LR_vector distance(std::pair<BaseParticle *, BaseParticle *> &pair);
 number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle *, BaseParticle *>> &all_pairs);
 number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair);
+std::pair<LR_vector, LR_vector> get_pair_force_torque_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair, BaseParticle *current_particle);
+number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vector &torque);
+number der_smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy);
 number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy);
 
 }

--- a/src/Forces/Metadynamics/meta_utils.h
+++ b/src/Forces/Metadynamics/meta_utils.h
@@ -39,6 +39,22 @@ std::tuple<std::vector<int>, std::vector<BaseParticle *>> get_particle_lists(inp
 
 std::vector<number> split_to_numbers(const std::string &str, const std::string &delims);
 
+struct CoordSettings {
+	int coord_mode;
+	number hb_energy_cutoff, hb_transition_width, d0, r0;
+	int n;
+
+	CoordSettings();
+
+	void get_settings(input_file &inp);
+};
+
+LR_vector distance(std::pair<BaseParticle *, BaseParticle *> &pair);
+number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle *, BaseParticle *>> &all_pairs);
+number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair);
+number hb_energy(BaseParticle *p1, BaseParticle *p2);
+number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy);
+
 }
 
 #endif /* SRC_FORCES_METADYNAMICS_META_UTILS_H_ */

--- a/src/Forces/Metadynamics/meta_utils.h
+++ b/src/Forces/Metadynamics/meta_utils.h
@@ -40,7 +40,10 @@ std::tuple<std::vector<int>, std::vector<BaseParticle *>> get_particle_lists(inp
 std::vector<number> split_to_numbers(const std::string &str, const std::string &delims);
 
 struct CoordSettings {
-	int coord_mode;
+	enum class CoordMode { HB_ENERGY, SWITCHING_FUNCTION, MIXED } coord_mode;
+	// only used if coord_mode == MIXED, must be between 0 and 1. The contribution of the HB_ENERGY mode will be multiplied 
+	// by this weight, while the contribution of the SWITCHING_FUNCTION mode will be multiplied by (1 - mixed_weight)
+	number mixed_weight;
 	number hb_energy_cutoff, hb_transition_width, d0, r0;
 	int n;
 

--- a/src/Forces/Metadynamics/meta_utils.h
+++ b/src/Forces/Metadynamics/meta_utils.h
@@ -55,7 +55,7 @@ struct CoordSettings {
 number coordination(CoordSettings &settings, std::vector<std::pair<BaseParticle *, BaseParticle *>> &all_pairs);
 number get_pair_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair);
 std::pair<LR_vector, LR_vector> get_pair_force_torque_contribution(CoordSettings &settings, std::pair<BaseParticle*, BaseParticle*> &pair, BaseParticle *current_particle);
-number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vector &torque);
+number hb_interaction(BaseParticle *p, BaseParticle *q, LR_vector &force, LR_vector &torque, bool compute_force_torque=true);
 number der_smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy);
 number smooth_hb_contribution(number hb_energy_cutoff, number hb_transition_width, number hb_energy);
 

--- a/src/Forces/MovingTrap.cpp
+++ b/src/Forces/MovingTrap.cpp
@@ -47,7 +47,7 @@ std::tuple<std::vector<int>, std::string> MovingTrap::init(input_file &inp) {
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector MovingTrap::value(llint step, LR_vector &pos) {
+LR_vector MovingTrap::force(llint step, LR_vector &pos) {
 	LR_vector postrap;
 	number x, y, z;
 

--- a/src/Forces/MovingTrap.h
+++ b/src/Forces/MovingTrap.h
@@ -18,7 +18,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/MutualTrap.cpp
+++ b/src/Forces/MutualTrap.cpp
@@ -60,7 +60,7 @@ LR_vector MutualTrap::_distance(LR_vector u, LR_vector v) {
 	}
 }
 
-LR_vector MutualTrap::value(llint step, LR_vector &pos) {
+LR_vector MutualTrap::force(llint step, LR_vector &pos) {
 	LR_vector dr = _distance(pos, CONFIG_INFO->box->get_abs_pos(_p_ptr));
 	return (dr / dr.module()) * (dr.module() - (_r0 + (_rate * step))) * (_stiff + (_stiff_rate * step));
 }

--- a/src/Forces/MutualTrap.h
+++ b/src/Forces/MutualTrap.h
@@ -28,7 +28,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 
 protected:

--- a/src/Forces/RepulsionPlane.cpp
+++ b/src/Forces/RepulsionPlane.cpp
@@ -52,7 +52,7 @@ number RepulsionPlane::_updated_position(llint step) {
 	return position;
 }
 
-LR_vector RepulsionPlane::value(llint step, LR_vector &pos) {
+LR_vector RepulsionPlane::force(llint step, LR_vector &pos) {
 	number distance = _direction * pos + _updated_position(step);
 	if(distance >= 0.) return LR_vector(0., 0., 0.);
 	else return -(distance * _stiff) * _direction;

--- a/src/Forces/RepulsionPlane.h
+++ b/src/Forces/RepulsionPlane.h
@@ -47,7 +47,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/RepulsionPlaneMoving.cpp
+++ b/src/Forces/RepulsionPlaneMoving.cpp
@@ -53,7 +53,7 @@ std::tuple<std::vector<int>, std::string> RepulsionPlaneMoving::init(input_file 
 	return std::make_tuple(particle_indices_vector, description);
 }
 
-LR_vector RepulsionPlaneMoving::value(llint step, LR_vector &pos) {
+LR_vector RepulsionPlaneMoving::force(llint step, LR_vector &pos) {
 	LR_vector force(0., 0., 0.);
 	for(std::vector<int>::size_type i = 0; i < ref_p_ptr.size(); i++) {
 		number distance = (pos - CONFIG_INFO->box->get_abs_pos(ref_p_ptr[i])) * _direction;

--- a/src/Forces/RepulsionPlaneMoving.h
+++ b/src/Forces/RepulsionPlaneMoving.h
@@ -48,7 +48,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/RepulsiveEllipsoid.cpp
+++ b/src/Forces/RepulsiveEllipsoid.cpp
@@ -52,7 +52,7 @@ std::tuple<std::vector<int>, std::string> RepulsiveEllipsoid::init(input_file &i
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector RepulsiveEllipsoid::value(llint step, LR_vector &pos) {
+LR_vector RepulsiveEllipsoid::force(llint step, LR_vector &pos) {
 	LR_vector dist = CONFIG_INFO->box->min_image(_centre, pos);
 
 	double internal_cut = SQR(dist.x) / SQR(_r_2.x) + SQR(dist.y) / SQR(_r_2.y) + SQR(dist.z) / SQR(_r_2.z);

--- a/src/Forces/RepulsiveEllipsoid.h
+++ b/src/Forces/RepulsiveEllipsoid.h
@@ -50,7 +50,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/RepulsiveKeplerPoinsot.cpp
+++ b/src/Forces/RepulsiveKeplerPoinsot.cpp
@@ -236,7 +236,7 @@ static inline bool star_metric_and_grad(
     return found;
 }
 
-LR_vector RepulsiveKeplerPoinsot::value(llint step, LR_vector &pos) {
+LR_vector RepulsiveKeplerPoinsot::force(llint step, LR_vector &pos) {
     const number growth = (number)1.0 + _rate * (number)step;
     if(growth <= (number)0.0) return LR_vector(0,0,0);
 

--- a/src/Forces/RepulsiveKeplerPoinsot.h
+++ b/src/Forces/RepulsiveKeplerPoinsot.h
@@ -51,7 +51,7 @@ public:
 
     std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-    LR_vector value(llint step, LR_vector &pos) override;
+    LR_vector force(llint step, LR_vector &pos) override;
     number potential(llint step, LR_vector &pos) override;
 };
 

--- a/src/Forces/RepulsiveSphere.cpp
+++ b/src/Forces/RepulsiveSphere.cpp
@@ -43,7 +43,7 @@ std::tuple<std::vector<int>, std::string> RepulsiveSphere::init(input_file &inp)
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector RepulsiveSphere::value(llint step, LR_vector &pos) {
+LR_vector RepulsiveSphere::force(llint step, LR_vector &pos) {
 	LR_vector dist = CONFIG_INFO->box->min_image(_center, pos);
 	number mdist = dist.module();
 	number radius = _r0 + _rate * (number) step;

--- a/src/Forces/RepulsiveSphere.h
+++ b/src/Forces/RepulsiveSphere.h
@@ -50,7 +50,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/RepulsiveSphereMoving.cpp
+++ b/src/Forces/RepulsiveSphereMoving.cpp
@@ -102,7 +102,7 @@ LR_vector RepulsiveSphereMoving::center_for_step(llint step) const {
     return _origin + (_target - _origin) * t;
 }
 
-LR_vector RepulsiveSphereMoving::value(llint step, LR_vector &pos) {
+LR_vector RepulsiveSphereMoving::force(llint step, LR_vector &pos) {
     LR_vector c     = center_for_step(step);
     LR_vector dist  = CONFIG_INFO->box->min_image(c, pos); // vector from center -> pos (minimum image)
     number mdist    = dist.module();

--- a/src/Forces/RepulsiveSphereMoving.h
+++ b/src/Forces/RepulsiveSphereMoving.h
@@ -20,7 +20,7 @@ public:
 
     // oxDNA hooks
     std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
-    LR_vector value(llint step, LR_vector &pos) override;
+    LR_vector force(llint step, LR_vector &pos) override;
     number    potential(llint step, LR_vector &pos) override;
     
     // --- CUDA/host-side accessors (needed by CUDAForces.h) ---

--- a/src/Forces/RepulsiveSphereSmooth.cpp
+++ b/src/Forces/RepulsiveSphereSmooth.cpp
@@ -45,7 +45,7 @@ std::tuple<std::vector<int>, std::string> RepulsiveSphereSmooth::init(input_file
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector RepulsiveSphereSmooth::value(llint step, LR_vector &pos) {
+LR_vector RepulsiveSphereSmooth::force(llint step, LR_vector &pos) {
 	LR_vector dist = CONFIG_INFO->box->min_image(_center, pos);
 	number mdist = dist.module();
 

--- a/src/Forces/RepulsiveSphereSmooth.h
+++ b/src/Forces/RepulsiveSphereSmooth.h
@@ -54,7 +54,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/SawtoothForce.cpp
+++ b/src/Forces/SawtoothForce.cpp
@@ -42,7 +42,7 @@ std::tuple<std::vector<int>, std::string> SawtoothForce::init(input_file &inp) {
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector SawtoothForce::value(llint step, LR_vector &pos) {
+LR_vector SawtoothForce::force(llint step, LR_vector &pos) {
 	number x = (_F0 + (int) ((step - 1) / _wait_time) * _increment) * _direction.x;
 	number y = (_F0 + (int) ((step - 1) / _wait_time) * _increment) * _direction.y;
 	number z = (_F0 + (int) ((step - 1) / _wait_time) * _increment) * _direction.z;

--- a/src/Forces/SawtoothForce.h
+++ b/src/Forces/SawtoothForce.h
@@ -39,7 +39,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Forces/YukawaSphere.cpp
+++ b/src/Forces/YukawaSphere.cpp
@@ -50,7 +50,7 @@ std::tuple<std::vector<int>, std::string> YukawaSphere::init(input_file &inp) {
 	return std::make_tuple(particle_ids, description);
 }
 
-LR_vector YukawaSphere::value(llint step, LR_vector &pos) {
+LR_vector YukawaSphere::force(llint step, LR_vector &pos) {
 	LR_vector dist = CONFIG_INFO->box->min_image(_center, pos);
 	number dist_surface = _radius - dist.module();
 	if(dist_surface < 0) {

--- a/src/Forces/YukawaSphere.h
+++ b/src/Forces/YukawaSphere.h
@@ -29,7 +29,7 @@ public:
 
 	std::tuple<std::vector<int>, std::string> init(input_file &inp) override;
 
-	virtual LR_vector value(llint step, LR_vector &pos);
+	virtual LR_vector force(llint step, LR_vector &pos);
 	virtual number potential(llint step, LR_vector &pos);
 };
 

--- a/src/Interactions/BaseInteraction.cpp
+++ b/src/Interactions/BaseInteraction.cpp
@@ -46,6 +46,14 @@ number BaseInteraction::pair_interaction_term(int name, BaseParticle *p, BasePar
 	return interaction->second(p, q, false, update_forces);
 }
 
+const BaseInteraction::energy_function& BaseInteraction::get_interaction_function(int name) {
+	typename interaction_map::iterator interaction = _interaction_map.find(name);
+	if(interaction == _interaction_map.end()) {
+		throw oxDNAException("%s, line %d: Interaction term '%d' not found", __FILE__, __LINE__, name);
+	}
+	return interaction->second;
+}
+
 std::map<int, number> BaseInteraction::get_system_energy_split(std::vector<BaseParticle *> &particles, BaseList *lists) {
 	begin_energy_computation();
 

--- a/src/Interactions/BaseInteraction.h
+++ b/src/Interactions/BaseInteraction.h
@@ -23,7 +23,9 @@
  * @brief Base class for managing particle-particle interactions. It is an abstract class.
  */
 class BaseInteraction {
-private:
+public:
+	using energy_function = std::function<number(BaseParticle *, BaseParticle *, bool, bool)>;
+	using interaction_map = std::map<int, energy_function>;
 
 protected:
 	BaseBox *_box;
@@ -48,8 +50,6 @@ protected:
 
 	virtual void _update_stress_tensor(const LR_vector &r_p, const LR_vector &group_force);
 
-	using energy_function = std::function<number(BaseParticle *, BaseParticle *, bool, bool)>;
-	using interaction_map = std::map<int, energy_function>;
 	interaction_map _interaction_map;
 
 public:
@@ -174,6 +174,17 @@ public:
 	 * @return
 	 */
 	virtual number pair_interaction_term(int name, BaseParticle *p, BaseParticle *q, bool compute_r = true, bool update_forces = false);
+
+	/**
+	 * @brief Returns a reference to the energy function for a given interaction term.
+	 *
+	 * This method is useful for caching function pointers to avoid repeated map lookups in hot code paths.
+	 * Throws an exception if the interaction term is not found.
+	 *
+	 * @param name identifier of the interaction method
+	 * @return const reference to the energy_function
+	 */
+	virtual const energy_function& get_interaction_function(int name);
 
 	/**
 	 * @brief Returns the total potential energy of the system

--- a/src/Observables/Coordination.cpp
+++ b/src/Observables/Coordination.cpp
@@ -27,10 +27,6 @@ void Coordination::get_settings(input_file &my_inp, input_file &sim_inp) {
 void Coordination::init() {
 	BaseObservable::init();
 
-    if(_settings.n % 2 != 0) {
-        throw oxDNAException("Coordination: exponent n must be an even integer");
-    }
-
     OrderParameters op;
     op.init_from_file(_op_file.c_str(), CONFIG_INFO->particles(), CONFIG_INFO->N());
     if(op.get_distance_parameters_count() > 0) {

--- a/src/Observables/Coordination.cpp
+++ b/src/Observables/Coordination.cpp
@@ -21,16 +21,13 @@ void Coordination::get_settings(input_file &my_inp, input_file &sim_inp) {
 	BaseObservable::get_settings(my_inp, sim_inp);
 
     getInputString(&my_inp, "op_file", _op_file, 1);
-
-    getInputNumber(&my_inp, "d0", &_d0, 0);
-	getInputNumber(&my_inp, "r0", &_r0, 0);
-    getInputInt(&my_inp, "n", &_n, 0);
+    _settings.get_settings(my_inp);
 }
 
 void Coordination::init() {
 	BaseObservable::init();
 
-    if(_n % 2 != 0) {
+    if(_settings.n % 2 != 0) {
         throw oxDNAException("Coordination: exponent n must be an even integer");
     }
 
@@ -73,18 +70,6 @@ void Coordination::init() {
 }
 
 std::string Coordination::get_output_string(llint curr_step) {
-    number coordination = 0.0;
-    for(auto &pair : _all_pairs) {
-        number r = _distance(pair).module();
-        coordination += 1.0 / (1.0 + std::pow((r - _d0) / _r0, _n));
-    }
-
+    number coordination = meta::coordination(_settings, _all_pairs);
     return Utils::sformat("%lf", coordination);
-}
-
-LR_vector Coordination::_distance(std::pair<BaseParticle *, BaseParticle *> &pair) {
-    LR_vector p_base = pair.first->pos + pair.first->int_centers[DNANucleotide::BASE];
-    LR_vector q_base = pair.second->pos + pair.second->int_centers[DNANucleotide::BASE];
-
-    return CONFIG_INFO->box->min_image(p_base, q_base);
 }

--- a/src/Observables/Coordination.cpp
+++ b/src/Observables/Coordination.cpp
@@ -75,9 +75,16 @@ void Coordination::init() {
 std::string Coordination::get_output_string(llint curr_step) {
     number coordination = 0.0;
     for(auto &pair : _all_pairs) {
-        number r = std::sqrt(CONFIG_INFO->box->sqr_min_image_distance(pair.first->pos, pair.second->pos));
+        number r = _distance(pair).module();
         coordination += 1.0 / (1.0 + std::pow((r - _d0) / _r0, _n));
     }
 
     return Utils::sformat("%lf", coordination);
+}
+
+LR_vector Coordination::_distance(std::pair<BaseParticle *, BaseParticle *> &pair) {
+    LR_vector p_base = pair.first->pos + pair.first->int_centers[DNANucleotide::BASE];
+    LR_vector q_base = pair.second->pos + pair.second->int_centers[DNANucleotide::BASE];
+
+    return CONFIG_INFO->box->min_image(p_base, q_base);
 }

--- a/src/Observables/Coordination.h
+++ b/src/Observables/Coordination.h
@@ -22,10 +22,12 @@ public:
 
 private:
     std::string _op_file;
-    number _d0 = 1.2; // optimal distance for coordination, defaults to 1.2 in internal units
+    number _d0 = 0.4; // optimal distance for coordination, defaults to 1.2 in internal units
     number _r0 = 0.5; // width of the switching function, defaults to 0.5 in internal units
     int _n = 6; // exponent of the switching function, defaults to 6
     std::vector<std::pair<BaseParticle *, BaseParticle *>> _all_pairs;
+
+    LR_vector _distance(std::pair<BaseParticle *, BaseParticle *> &pair);
 };
 
 #endif /* COORDINATION_H */

--- a/src/Observables/Coordination.h
+++ b/src/Observables/Coordination.h
@@ -10,6 +10,8 @@
 
 #include "BaseObservable.h"
 
+#include "../Forces/Metadynamics/meta_utils.h"
+
 class Coordination: public BaseObservable {
 public:
     Coordination();
@@ -22,12 +24,9 @@ public:
 
 private:
     std::string _op_file;
-    number _d0 = 0.4; // optimal distance for coordination, defaults to 1.2 in internal units
-    number _r0 = 0.5; // width of the switching function, defaults to 0.5 in internal units
-    int _n = 6; // exponent of the switching function, defaults to 6
-    std::vector<std::pair<BaseParticle *, BaseParticle *>> _all_pairs;
 
-    LR_vector _distance(std::pair<BaseParticle *, BaseParticle *> &pair);
+    meta::CoordSettings _settings;
+    std::vector<std::pair<BaseParticle *, BaseParticle *>> _all_pairs;
 };
 
 #endif /* COORDINATION_H */

--- a/src/Observables/ExternalTorque.cpp
+++ b/src/Observables/ExternalTorque.cpp
@@ -59,7 +59,7 @@ std::string ExternalTorque::get_output_string(llint curr_step) {
 			LR_vector total_force = LR_vector((number) 0., (number) 0., (number) 0.);
 			for(auto ext_force : p->ext_forces) {
 				ext_force->set_current_particle(p);
-				total_force += ext_force->value(curr_step, abs_pos);
+				total_force += ext_force->force(curr_step, abs_pos);
 			}
 			tau += distvec.cross(total_force);
 		}
@@ -69,7 +69,7 @@ std::string ExternalTorque::get_output_string(llint curr_step) {
 				if(ext_force->get_group_name() == std::string(_group_name)) {
 					//printf("Adding torque on particle %i\n", i);
 					ext_force->set_current_particle(p);
-					tau += distvec.cross(ext_force->value(curr_step, abs_pos));
+					tau += distvec.cross(ext_force->force(curr_step, abs_pos));
 				}
 			}
 		}

--- a/src/Particles/BaseParticle.cpp
+++ b/src/Particles/BaseParticle.cpp
@@ -72,7 +72,7 @@ void BaseParticle::set_initial_forces(llint step, BaseBox *box) {
 	if(ext_forces.size() > 0) {
 		LR_vector abs_pos = box->get_abs_pos(this);
 		for(auto ext_force : ext_forces) {
-			force += ext_force->value(step, abs_pos);
+			force += ext_force->force(step, abs_pos);
 		}
 	}
 }
@@ -83,6 +83,10 @@ void BaseParticle::set_ext_potential(llint step, BaseBox *box) {
 		ext_potential = (number) 0.;
 		for(auto ext_force : ext_forces) {
 			ext_potential += ext_force->potential(step, abs_pos);
+
+			if(is_rigid_body()) {
+				torque += ext_force->torque(step, abs_pos);
+			}
 		}
 	}
 }

--- a/src/Particles/BaseParticle.cpp
+++ b/src/Particles/BaseParticle.cpp
@@ -72,7 +72,12 @@ void BaseParticle::set_initial_forces(llint step, BaseBox *box) {
 	if(ext_forces.size() > 0) {
 		LR_vector abs_pos = box->get_abs_pos(this);
 		for(auto ext_force : ext_forces) {
+			ext_force->set_current_particle(this);
 			force += ext_force->force(step, abs_pos);
+
+			if(is_rigid_body()) {
+				torque += orientationT * ext_force->torque(step, abs_pos);
+			}
 		}
 	}
 }
@@ -82,11 +87,8 @@ void BaseParticle::set_ext_potential(llint step, BaseBox *box) {
 		LR_vector abs_pos = box->get_abs_pos(this);
 		ext_potential = (number) 0.;
 		for(auto ext_force : ext_forces) {
+			ext_force->set_current_particle(this);
 			ext_potential += ext_force->potential(step, abs_pos);
-
-			if(is_rigid_body()) {
-				torque += ext_force->torque(step, abs_pos);
-			}
 		}
 	}
 }

--- a/src/Particles/BaseParticle.cpp
+++ b/src/Particles/BaseParticle.cpp
@@ -76,9 +76,13 @@ void BaseParticle::set_initial_forces(llint step, BaseBox *box) {
 			force += ext_force->force(step, abs_pos);
 
 			if(is_rigid_body()) {
-				torque += orientationT * ext_force->torque(step, abs_pos);
+				torque += ext_force->torque(step, abs_pos);
 			}
 		}
+	}
+
+	if(is_rigid_body()) {
+		torque = orientationT * torque;
 	}
 }
 

--- a/src/Particles/SpheroCylinder.cpp
+++ b/src/Particles/SpheroCylinder.cpp
@@ -52,8 +52,8 @@ void SpheroCylinder::set_initial_forces(llint step, BaseBox * box) {
 	for(auto ext_force : this->ext_forces) {
 		ext_force->set_current_particle(this);
 		LR_vector my_abs_pos = abs_pos + this->int_centers[TOP];
-		this->force += ext_force->value(step, my_abs_pos);
+		this->force += ext_force->force(step, my_abs_pos);
 		my_abs_pos = abs_pos + this->int_centers[BOT];
-		this->force += ext_force->value(step, my_abs_pos);
+		this->force += ext_force->force(step, my_abs_pos);
 	}
 }

--- a/src/Utilities/Utils.h
+++ b/src/Utilities/Utils.h
@@ -118,6 +118,15 @@ LR_vector get_random_vector_in_sphere(number r);
 void orthonormalize_matrix(LR_matrix &M);
 
 /**
+ * @brief Returns a matrix which generates a rotation around the given axis of the given angle.
+ * 
+ * @param axis the rotation axis, must be a unit vector
+ * @param angle the rotation angle in radians
+ * @return the rotation matrix
+ */
+LR_matrix get_rotation_matrix_from_axis_angle(const LR_vector &axis, number angle);
+
+/**
  * @brief Returns a matrix which generates a rotation around a random axis of a random angle, extracted between 0 and max_angle.
  *
  * @param max_angle
@@ -248,9 +257,7 @@ inline LR_vector Utils::get_random_vector_in_sphere(number r) {
 	return res;
 }
 
-inline LR_matrix Utils::get_random_rotation_matrix_from_angle(number angle) {
-	LR_vector axis = Utils::get_random_vector();
-
+inline LR_matrix Utils::get_rotation_matrix_from_axis_angle(const LR_vector &axis, number angle) {
 	number t = angle;
 	number sintheta = sin(t);
 	number costheta = cos(t);
@@ -263,9 +270,17 @@ inline LR_matrix Utils::get_random_rotation_matrix_from_angle(number angle) {
 	number ysin = axis.y * sintheta;
 	number zsin = axis.z * sintheta;
 
-	LR_matrix R(axis.x * axis.x * olcos + costheta, xyo - zsin, xzo + ysin, xyo + zsin, axis.y * axis.y * olcos + costheta, yzo - xsin, xzo - ysin, yzo + xsin, axis.z * axis.z * olcos + costheta);
+	LR_matrix R(
+		axis.x * axis.x * olcos + costheta, xyo - zsin, xzo + ysin, 
+		xyo + zsin, axis.y * axis.y * olcos + costheta, yzo - xsin, 
+		xzo - ysin, yzo + xsin, axis.z * axis.z * olcos + costheta);
 
 	return R;
+}
+
+inline LR_matrix Utils::get_random_rotation_matrix_from_angle(number angle) {
+	LR_vector axis = Utils::get_random_vector();
+	return get_rotation_matrix_from_axis_angle(axis, angle);
 }
 
 inline LR_matrix Utils::get_random_rotation_matrix(number max_angle) {

--- a/src/oxpy/bindings_includes/Forces/BaseForce.h
+++ b/src/oxpy/bindings_includes/Forces/BaseForce.h
@@ -38,11 +38,24 @@ public:
 		return std::tuple<std::vector<int>, std::string>();
 	}
 
-	LR_vector value(llint step, LR_vector &pos) override {
-		PYBIND11_OVERLOAD_PURE( // @suppress("Unused return value")
+	LR_vector force(llint step, LR_vector &pos) override {
+		PYBIND11_OVERLOAD( // @suppress("Unused return value")
 				LR_vector,
 				BaseForce,
-				value,
+				force,
+				step,
+				pos
+		);
+
+		// suppress warnings
+		return LR_vector();
+	}
+
+	LR_vector torque(llint step, LR_vector &pos) override {
+		PYBIND11_OVERLOAD( // @suppress("Unused return value")
+				LR_vector,
+				BaseForce,
+				torque,
 				step,
 				pos
 		);
@@ -89,20 +102,52 @@ void export_BaseForce(py::module &m) {
 	force.def_property("id", &BaseForce::get_id, &BaseForce::set_id, "The id of the force.");
 	force.def_property_readonly("type", &BaseForce::get_type, "the string used in the external force file to specify the force type (*e.g.* `trap`).");
 
-	force.def("value", &BaseForce::value, py::arg("step"), py::arg("pos"), R"pbdoc(
-        Return the force vector that would act at the given position and time step.
+	force.def("force", &BaseForce::force, py::arg("step"), py::arg("pos"), R"pbdoc(
+		Return the force vector that would act at the given position and time step.
 
-        Parameters
-        ----------
-        step: int
-            The current time step.
-        pos: numpy.ndarray
-            The position where the force should be computed.
+		Parameters
+		----------
+		step: int
+			The current time step.
+		pos: numpy.ndarray
+			The absolute position at which the force should be computed.
 
-        Returns
-        -------
-        numpy.ndarray
-            The computed force vector.
+		Returns
+		-------
+		numpy.ndarray
+			The computed force vector.
+	)pbdoc");
+
+	force.def("value", &BaseForce::force, py::arg("step"), py::arg("pos"), R"pbdoc(
+		DEPRECATED: Use `force` instead. Return the force vector that would act at the given position and time step.
+
+		Parameters
+		----------
+		step: int
+			The current time step.
+		pos: numpy.ndarray
+			The absolute position at which the force should be computed.
+
+		Returns
+		-------
+		numpy.ndarray
+			The computed force vector.
+	)pbdoc");
+
+	force.def("torque", &BaseForce::torque, py::arg("step"), py::arg("pos"), R"pbdoc(
+		Return the torque vector that would act at the given position and time step.
+
+		Parameters
+		----------
+		step: int
+			The current time step.
+		pos: numpy.ndarray
+			The absolute position at which the torque should be computed.
+
+		Returns
+		-------
+		numpy.ndarray
+			The computed torque vector.
 	)pbdoc");
 
 	force.def("potential", &BaseForce::potential, py::arg("step"), py::arg("pos"), R"pbdoc(


### PR DESCRIPTION
This PR makes it possible to write external forces that also exert torques, both on CPU and GPU. In order to avoid confusion, the `value` method of BaseForce is changed into `force`, and a `torque` method is added. In order to avoid disruptions to scripts using oxpy, both `value` and `force` can be used to get the current force from a `BaseForce` object.